### PR TITLE
fix(app service msi): Use a GET request to obtain app service MSI credentials

### DIFF
--- a/lib/credentials/msiAppServiceTokenCredentials.ts
+++ b/lib/credentials/msiAppServiceTokenCredentials.ts
@@ -10,13 +10,13 @@ import { HttpOperationResponse, RequestPrepareOptions, WebResource } from "@azur
 export interface MSIAppServiceOptions extends MSIOptions {
   /**
    * @property {string} [msiEndpoint] - The local URL from which your app can request tokens.
-   * Either provide this parameter or set the environment varaible `MSI_ENDPOINT`.
+   * Either provide this parameter or set the environment variable `MSI_ENDPOINT`.
    * For example: `export MSI_ENDPOINT="http://127.0.0.1:41741/MSI/token/"`
    */
   msiEndpoint?: string;
   /**
    * @property {string} [msiSecret] - The secret used in communication between your code and the local MSI agent.
-   * Either provide this parameter or set the environment varaible `MSI_SECRET`.
+   * Either provide this parameter or set the environment variable `MSI_SECRET`.
    * For example: `export MSI_SECRET="69418689F1E342DD946CB82994CDA3CB"`
    */
   msiSecret?: string;
@@ -32,13 +32,13 @@ export interface MSIAppServiceOptions extends MSIOptions {
 export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
   /**
    * @property {string} msiEndpoint - The local URL from which your app can request tokens.
-   * Either provide this parameter or set the environment varaible `MSI_ENDPOINT`.
+   * Either provide this parameter or set the environment variable `MSI_ENDPOINT`.
    * For example: `MSI_ENDPOINT="http://127.0.0.1:41741/MSI/token/"`
    */
   msiEndpoint: string;
   /**
    * @property {string} msiSecret - The secret used in communication between your code and the local MSI agent.
-   * Either provide this parameter or set the environment varaible `MSI_SECRET`.
+   * Either provide this parameter or set the environment variable `MSI_SECRET`.
    * For example: `MSI_SECRET="69418689F1E342DD946CB82994CDA3CB"`
    */
   msiSecret: string;
@@ -50,10 +50,10 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
   /**
    * Creates an instance of MSIAppServiceTokenCredentials.
    * @param {string} [options.msiEndpoint] - The local URL from which your app can request tokens.
-   * Either provide this parameter or set the environment varaible `MSI_ENDPOINT`.
+   * Either provide this parameter or set the environment variable `MSI_ENDPOINT`.
    * For example: `MSI_ENDPOINT="http://127.0.0.1:41741/MSI/token/"`
    * @param {string} [options.msiSecret] - The secret used in communication between your code and the local MSI agent.
-   * Either provide this parameter or set the environment varaible `MSI_SECRET`.
+   * Either provide this parameter or set the environment variable `MSI_SECRET`.
    * For example: `MSI_SECRET="69418689F1E342DD946CB82994CDA3CB"`
    * @param {string} [options.resource] - The resource uri or token audience for which the token is needed.
    * For e.g. it can be:
@@ -113,15 +113,14 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
 
   protected prepareRequestOptions(): WebResource {
     const endpoint = this.msiEndpoint.endsWith("/") ? this.msiEndpoint : `${this.msiEndpoint}/`;
-    const getUrl = `${endpoint}?resource=${this.resource}&api-version=${this.msiApiVersion}`;
     const resource = encodeURIComponent(this.resource);
+    const getUrl = `${endpoint}?resource=${resource}&api-version=${this.msiApiVersion}`;
     const reqOptions: RequestPrepareOptions = {
       url: getUrl,
       headers: {
         "secret": this.msiSecret
       },
-      body: `resource=${resource}`,
-      method: "POST"
+      method: "GET"
     };
 
     const webResource = new WebResource();

--- a/lib/credentials/msiAppServiceTokenCredentials.ts
+++ b/lib/credentials/msiAppServiceTokenCredentials.ts
@@ -88,7 +88,7 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
   }
 
   /**
-   * Prepares and sends a POST request to a service endpoint hosted on the Azure VM, which responds with the access token.
+   * Prepares and sends a GET request to a service endpoint indicated by the app service, which responds with the access token.
    * @return {Promise<MSITokenResponse>} Promise with the tokenResponse (tokenType and accessToken are the two important properties).
    */
   async getToken(): Promise<MSITokenResponse> {

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -799,10 +799,10 @@ function _withAppServiceMSI(options: MSIAppServiceOptions): Promise<MSIAppServic
  * Authenticate using the App Service MSI.
  * @param {object} [options] - Optional parameters
  * @param {string} [options.msiEndpoint] - The local URL from which your app can request tokens.
- * Either provide this parameter or set the environment varaible `MSI_ENDPOINT`.
+ * Either provide this parameter or set the environment variable `MSI_ENDPOINT`.
  * For example: `MSI_ENDPOINT="http://127.0.0.1:41741/MSI/token/"`
  * @param {string} [options.msiSecret] - The secret used in communication between your code and the local MSI agent.
- * Either provide this parameter or set the environment varaible `MSI_SECRET`.
+ * Either provide this parameter or set the environment variable `MSI_SECRET`.
  * For example: `MSI_SECRET="69418689F1E342DD946CB82994CDA3CB"`
  * @param {string} [options.resource] - The resource uri or token audience for which the token is needed.
  * For example, it can be:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Azure Authentication library in node.js with type definitions.",
   "tags": [
     "node",


### PR DESCRIPTION
We've been trying to migrate an application from the old ms-rest-azure package and noticed that we were unable to obtain MSI credentials in an Azure Functions app. That seems to have been caused by the fact that a POST request was used as opposed to a GET request as documented in the [REST protocol examples](https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#rest-protocol-examples). This PR addresses the problem. 

As a bonus, there's small recurring typo fix.