### PR TITLE
Add TokenCredential and BearerTokenAuthenticationPolicy

### DIFF
--- a/lib/identity/bearerTokenAuthenticationPolicy.ts
+++ b/lib/identity/bearerTokenAuthenticationPolicy.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { TokenCredential } from "./tokenCredential";
+import {
+  BaseRequestPolicy,
+  RequestPolicy,
+  RequestPolicyOptions,
+  Constants,
+  HttpHeaders,
+  HttpOperationResponse,
+  WebResource
+} from "@azure/ms-rest-js";
+
+/**
+ *
+ * Provides a RequestPolicy that can request a token from a TokenCredential
+ * implementation and then apply it to the Authorization header of a request
+ * as a Bearer token.
+ *
+ */
+export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
+  /**
+   * Creates a new BearerTokenAuthenticationPolicy object.
+   *
+   * @param nextPolicy The next RequestPolicy in the request pipeline.
+   * @param options Options for this RequestPolicy.
+   * @param credential The TokenCredential implementation that can supply the bearer token.
+   * @param scope The scope for which the bearer token applies.
+   */
+  constructor(
+    nextPolicy: RequestPolicy,
+    options: RequestPolicyOptions,
+    private credential: TokenCredential,
+    private scope: string
+  ) {
+    super(nextPolicy, options);
+  }
+
+  /**
+   * Applies the Bearer token to the request through the Authorization header.
+   * @param webResource
+   */
+  public async sendRequest(
+    webResource: WebResource
+  ): Promise<HttpOperationResponse> {
+    if (!webResource.headers) webResource.headers = new HttpHeaders();
+    const token = await this.credential.getToken(
+      [this.scope],
+      webResource.abortSignal
+    );
+    webResource.headers.set(
+      Constants.HeaderConstants.AUTHORIZATION,
+      `Bearer ${token}`
+    );
+    return this._nextPolicy.sendRequest(webResource);
+  }
+}

--- a/lib/identity/bearerTokenAuthenticationPolicy.ts
+++ b/lib/identity/bearerTokenAuthenticationPolicy.ts
@@ -26,13 +26,13 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
    * @param nextPolicy The next RequestPolicy in the request pipeline.
    * @param options Options for this RequestPolicy.
    * @param credential The TokenCredential implementation that can supply the bearer token.
-   * @param scope The scope for which the bearer token applies.
+   * @param scopes The scopes for which the bearer token applies.
    */
   constructor(
     nextPolicy: RequestPolicy,
     options: RequestPolicyOptions,
     private credential: TokenCredential,
-    private scope: string
+    private scopes: string[]
   ) {
     super(nextPolicy, options);
   }
@@ -46,7 +46,7 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
   ): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
     const token = await this.credential.getToken(
-      [this.scope],
+      this.scopes,
       webResource.abortSignal
     );
     webResource.headers.set(

--- a/lib/identity/tokenCredential.ts
+++ b/lib/identity/tokenCredential.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { AbortSignalLike } from "@azure/ms-rest-js";
+
+/**
+ * Represents a credential capable of providing an authentication token.
+ */
+export abstract class TokenCredential {
+  /**
+   * Gets the token provided by this credential.
+   *
+   * @param scopes The list of scopes for which the token will have access.
+   * @param aborter The AbortSignalLike used for aborting the token request.
+   */
+  public abstract getToken(
+    scopes: string[],
+    aborter?: AbortSignalLike
+  ): Promise<string>;
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/dotenv": "^6.1.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.0",
+    "@types/sinon": "^5.0.6",
     "chai": "^4.2.0",
     "dotenv": "^8.0.0",
     "mocha": "^5.2.0",
@@ -47,6 +48,7 @@
     "nyc": "^14.1.0",
     "rollup": "^0.67.1",
     "rollup-plugin-sourcemaps": "^0.4.2",
+    "sinon": "^7.1.1",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "typescript": "^3.1.3"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",

--- a/test/identity/bearerTokenAuthenticationPolicyTests.ts
+++ b/test/identity/bearerTokenAuthenticationPolicyTests.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { assert } from "chai";
+import { fake } from "sinon";
+import {
+  HttpHeaders,
+  HttpOperationResponse,
+  OperationSpec,
+  RequestPolicy,
+  WebResource,
+  RequestPolicyOptions,
+  Constants
+} from "@azure/ms-rest-js";
+import { BearerTokenAuthenticationPolicy } from "../../lib/identity/bearerTokenAuthenticationPolicy";
+import { TokenCredential } from "../../lib/identity/tokenCredential";
+
+describe("BearerTokenAuthenticationPolicy", function() {
+  const mockPolicy: RequestPolicy = {
+    sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+      return Promise.resolve({
+        request: request,
+        status: 200,
+        headers: new HttpHeaders()
+      });
+    }
+  };
+
+  it("correctly adds an Authentication header with the Bearer token", async function() {
+    const mockToken = "token";
+    const tokenScopes = ["scope1", "scope2"];
+    const fakeGetToken = fake.returns(Promise.resolve(mockToken));
+    const mockCredential: TokenCredential = {
+      getToken: fakeGetToken
+    };
+
+    const bearerTokenAuthPolicy = new BearerTokenAuthenticationPolicy(
+      mockPolicy,
+      new RequestPolicyOptions(),
+      mockCredential,
+      tokenScopes
+    );
+    const request = createRequest();
+    await bearerTokenAuthPolicy.sendRequest(request);
+
+    assert(fakeGetToken.calledWith(tokenScopes, undefined));
+    assert.strictEqual(
+      request.headers.get(Constants.HeaderConstants.AUTHORIZATION),
+      `Bearer ${mockToken}`
+    );
+  });
+
+  function createRequest(operationSpec?: OperationSpec): WebResource {
+    const request = new WebResource();
+    request.operationSpec = operationSpec;
+    return request;
+  }
+});


### PR DESCRIPTION
This PR kicks off the new Azure.Identity TypeScript library implementation by temporarily introducing the `TokenCredential` abstract class and `BearerTokenAuthenticationPolicy` class which can apply a token to requests in `ms-rest-js`'s HTTP request pipeline.

## Questions for Reviewers

- Is this the right library/folder to add these classes?  The policy implementation *seems* like it belongs with the other policies in [`ms-rest-js/lib/policies`](https://github.com/Azure/ms-rest-js/tree/master/lib/policies).  Perhaps this low-level implementation belongs in that library instead since it isn't specific to Node.js or the browser?
- Are the comments sufficient?  Are there any posted guidelines for how JSDoc comments should be written?
- The Prettier extension in VS Code has been auto-formatting these files when I save them.  Does the formatting look generally correct?

## Tasks

- [x] Add tests for the policy implementation

/cc @schaabs @bterlson
