### PR TITLE
Enforce azure cli to output json

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.0.2 - 2019/06/13
+ - Ensure we always get JSON responses back from Azure CLI.
+
 ## 2.0.1 - 2019/05/22
  - Get subscriptions while authenticating only if the token audience is for Azure Resource Manager.
 

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -967,7 +967,7 @@ export function loginWithAppServiceMSI(options?: MSIAppServiceOptions | Callback
  */
 export async function execAz(cmd: string): Promise<any> {
   return new Promise<any>((resolve, reject) => {
-    exec(`az ${cmd}`, { encoding: "utf8" }, (error, stdout) => {
+    exec(`az ${cmd} --out json`, { encoding: "utf8" }, (error, stdout) => {
       if (error) {
         return reject(error);
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
If you've run `az configure` to get non-json default output then you don't get JSON. As a result the `JSON.parse` immediately fails due to trying to parse the non-json format. This enforces retrieving in JSON format so that we can always parse it whatever the users default value