### PR TITLE
Cleanup `async function`s and `Promise` based code

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 3.0.1 - 2019/08/06
+- Reduce number of `Promise` object allocations inside `async` functions.
+
 ## 3.0.0 - 2019/08/02
 - **Breaking change:**
   - Updated min version of dependency `@azure/ms-rest-js` from `^1.8.13` to `^2.0.4` there by fixing [#67](https://github.com/Azure/ms-rest-nodeauth/issues/67).

--- a/lib/credentials/applicationTokenCertificateCredentials.ts
+++ b/lib/credentials/applicationTokenCertificateCredentials.ts
@@ -54,12 +54,12 @@ export class ApplicationTokenCertificateCredentials extends ApplicationTokenCred
    */
   public async getToken(): Promise<TokenResponse> {
     try {
-      const tokenResponse = await this.getTokenFromCache();
-      return tokenResponse;
+      return await this.getTokenFromCache();
     } catch (error) {
       if (error.message.startsWith(AuthConstants.SDK_INTERNAL_ERROR)) {
-        return Promise.reject(error);
+        throw error;
       }
+
       return new Promise((resolve, reject) => {
         const resource = this.getActiveDirectoryResourceId();
         this.authContext.acquireTokenWithClientCertificate(

--- a/lib/credentials/applicationTokenCredentials.ts
+++ b/lib/credentials/applicationTokenCredentials.ts
@@ -44,14 +44,13 @@ export class ApplicationTokenCredentials extends ApplicationTokenCredentialsBase
    */
   public async getToken(): Promise<TokenResponse> {
     try {
-      const tokenResponse = await this.getTokenFromCache();
-      return tokenResponse;
+      return await this.getTokenFromCache();
     } catch (error) {
       if (
         error.message &&
         error.message.startsWith(AuthConstants.SDK_INTERNAL_ERROR)
       ) {
-        return Promise.reject(error);
+        throw error;
       }
       const resource = this.getActiveDirectoryResourceId();
       return new Promise((resolve, reject) => {

--- a/lib/credentials/applicationTokenCredentialsBase.ts
+++ b/lib/credentials/applicationTokenCredentialsBase.ts
@@ -34,8 +34,7 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
 
     // a thin wrapper over the base implementation. try get token from cache, additionaly clean up cache if required.
     try {
-      const tokenResponse = await super.getTokenFromCache(undefined);
-      return Promise.resolve(tokenResponse);
+      return await super.getTokenFromCache(undefined);
     } catch (error) {
       // Remove the stale token from the tokencache. ADAL gives the same error message "Entry not found in cache."
       // for entry not being present in the cache and for accessToken being expired in the cache. We do not want the token cache
@@ -43,20 +42,21 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
       const status = await self.removeInvalidItemsFromCache({
         _clientId: self.clientId
       });
+
       if (status.result) {
-        return Promise.reject(error);
+        throw error;
       }
+
       const message =
         status && status.details && status.details.message
           ? status.details.message
           : status.details;
-      return Promise.reject(
-        new Error(
-          AuthConstants.SDK_INTERNAL_ERROR +
-          " : " +
-          "critical failure while removing expired token for service principal from token cache. " +
-          message
-        )
+
+      throw new Error(
+        AuthConstants.SDK_INTERNAL_ERROR +
+        " : " +
+        "critical failure while removing expired token for service principal from token cache. " +
+        message
       );
     }
   }

--- a/lib/credentials/applicationTokenCredentialsBase.ts
+++ b/lib/credentials/applicationTokenCredentialsBase.ts
@@ -30,8 +30,6 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
   }
 
   protected async getTokenFromCache(): Promise<TokenResponse> {
-    const self = this;
-
     // a thin wrapper over the base implementation. try get token from cache, additionaly clean up cache if required.
     try {
       return await super.getTokenFromCache(undefined);
@@ -39,8 +37,8 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
       // Remove the stale token from the tokencache. ADAL gives the same error message "Entry not found in cache."
       // for entry not being present in the cache and for accessToken being expired in the cache. We do not want the token cache
       // to contain the expired token, we clean it up here.
-      const status = await self.removeInvalidItemsFromCache({
-        _clientId: self.clientId
+      const status = await this.removeInvalidItemsFromCache({
+        _clientId: this.clientId
       });
 
       if (status.result) {

--- a/lib/credentials/azureCliCredentials.ts
+++ b/lib/credentials/azureCliCredentials.ts
@@ -156,7 +156,7 @@ export class AzureCliCredentials implements TokenClientCredentials {
       MSRestConstants.HeaderConstants.AUTHORIZATION,
       `${tokenResponse.tokenType} ${tokenResponse.accessToken}`
     );
-    return Promise.resolve(webResource);
+    return webResource;
   }
 
   private _hasTokenExpired(): boolean {

--- a/lib/credentials/msiAppServiceTokenCredentials.ts
+++ b/lib/credentials/msiAppServiceTokenCredentials.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { MSITokenCredentials, MSIOptions, MSITokenResponse } from "./msiTokenCredentials";
-import { HttpOperationResponse, RequestPrepareOptions, WebResource } from "@azure/ms-rest-js";
+import { RequestPrepareOptions, WebResource } from "@azure/ms-rest-js";
 
 /**
  * @interface MSIAppServiceOptions Defines the optional parameters for authentication with MSI for AppService.
@@ -93,15 +93,13 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
    */
   async getToken(): Promise<MSITokenResponse> {
     const reqOptions = this.prepareRequestOptions();
-    let opRes: HttpOperationResponse;
-    let result: MSITokenResponse;
 
-    opRes = await this._httpClient.sendRequest(reqOptions);
+    const opRes = await this._httpClient.sendRequest(reqOptions);
     if (opRes.bodyAsText === undefined || opRes.bodyAsText!.indexOf("ExceptionMessage") !== -1) {
       throw new Error(`MSI: Failed to retrieve a token from "${reqOptions.url}" with an error: ${opRes.bodyAsText}`);
     }
 
-    result = this.parseTokenResponse(opRes.bodyAsText!) as MSITokenResponse;
+    const result = this.parseTokenResponse(opRes.bodyAsText!) as MSITokenResponse;
     if (!result.tokenType) {
       throw new Error(`Invalid token response, did not find tokenType. Response body is: ${opRes.bodyAsText}`);
     } else if (!result.accessToken) {

--- a/lib/credentials/msiTokenCredentials.ts
+++ b/lib/credentials/msiTokenCredentials.ts
@@ -145,6 +145,6 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
   public async signRequest(webResource: WebResource): Promise<WebResource> {
     const tokenResponse = await this.getToken();
     webResource.headers.set(Constants.HeaderConstants.AUTHORIZATION, `${tokenResponse.tokenType} ${tokenResponse.accessToken}`);
-    return Promise.resolve(webResource);
+    return webResource;
   }
 }

--- a/lib/credentials/msiVmTokenCredentials.ts
+++ b/lib/credentials/msiVmTokenCredentials.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { MSITokenCredentials, MSIOptions, MSITokenResponse } from "./msiTokenCredentials";
-import { RequestPrepareOptions, HttpOperationResponse, WebResource, URLBuilder, HttpMethods } from "@azure/ms-rest-js";
+import { RequestPrepareOptions, WebResource, URLBuilder, HttpMethods } from "@azure/ms-rest-js";
 
 /**
  * @interface MSIVmOptions Defines the optional parameters for authentication with MSI for Virtual Machine.
@@ -93,11 +93,9 @@ export class MSIVmTokenCredentials extends MSITokenCredentials {
    */
   async getToken(): Promise<MSITokenResponse> {
     const reqOptions = this.prepareRequestOptions();
-    let opRes: HttpOperationResponse;
-    let result: MSITokenResponse;
 
-    opRes = await this._httpClient.sendRequest(reqOptions);
-    result = this.parseTokenResponse(opRes.bodyAsText!) as MSITokenResponse;
+    const opRes = await this._httpClient.sendRequest(reqOptions);
+    const result = this.parseTokenResponse(opRes.bodyAsText!) as MSITokenResponse;
     if (!result.tokenType) {
       throw new Error(`Invalid token response, did not find tokenType. Response body is: ${opRes.bodyAsText}`);
     } else if (!result.accessToken) {

--- a/lib/credentials/tokenCredentialsBase.ts
+++ b/lib/credentials/tokenCredentialsBase.ts
@@ -84,6 +84,6 @@ export abstract class TokenCredentialsBase implements TokenClientCredentials {
   public async signRequest(webResource: WebResource): Promise<WebResource> {
     const tokenResponse = await this.getToken();
     webResource.headers.set(MSRestConstants.HeaderConstants.AUTHORIZATION, `${tokenResponse.tokenType} ${tokenResponse.accessToken}`);
-    return Promise.resolve(webResource);
+    return webResource;
   }
 }

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -422,9 +422,7 @@ export async function withInteractiveWithAuthResponse(options?: InteractiveLogin
   if (!options) {
     options = {};
   }
-  if (!options) {
-    options = {};
-  }
+
   if (!options.environment) {
     options.environment = Environment.AzureCloud;
   }

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -785,7 +785,7 @@ function _getSubscriptions(
   tokenAudience?: string): Promise<LinkedSubscription[]> {
   if (tokenAudience &&
     !managementPlaneTokenAudiences.some((item) => { return item === tokenAudience!.toLowerCase(); })) {
-    return Promise.resolve(([]));
+    return Promise.resolve([]);
   }
   return getSubscriptionsFromTenants(creds, tenants);
 }

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -171,20 +171,15 @@ export async function withUsernamePasswordWithAuthResponse(username: string, pas
   if (!options.environment) {
     options.environment = Environment.AzureCloud;
   }
-  let creds: UserTokenCredentials;
-  let tenantList: string[] = [];
-  let subscriptionList: LinkedSubscription[] = [];
-  try {
-    creds = new UserTokenCredentials(options.clientId, options.domain, username, password, options.tokenAudience, options.environment);
-    await creds.getToken();
-    // The token cache gets propulated for all the tenants as a part of building the tenantList.
-    tenantList = await buildTenantList(creds);
-    subscriptionList = await _getSubscriptions(creds, tenantList, options.tokenAudience);
 
-  } catch (err) {
-    return Promise.reject(err);
-  }
-  return Promise.resolve({ credentials: creds, subscriptions: subscriptionList });
+  const creds = new UserTokenCredentials(options.clientId, options.domain, username, password, options.tokenAudience, options.environment);
+  await creds.getToken();
+
+  // The token cache gets propulated for all the tenants as a part of building the tenantList.
+  const tenantList = await buildTenantList(creds);
+  const subscriptionList: LinkedSubscription[] = await _getSubscriptions(creds, tenantList, options.tokenAudience);
+
+  return { credentials: creds, subscriptions: subscriptionList };
 }
 
 /**
@@ -210,16 +205,13 @@ export async function withServicePrincipalSecretWithAuthResponse(clientId: strin
   if (!options.environment) {
     options.environment = Environment.AzureCloud;
   }
-  let creds: ApplicationTokenCredentials;
-  let subscriptionList: LinkedSubscription[] = [];
-  try {
-    creds = new ApplicationTokenCredentials(clientId, domain, secret, options.tokenAudience, options.environment);
-    await creds.getToken();
-    subscriptionList = await _getSubscriptions(creds, [domain], options.tokenAudience);
-  } catch (err) {
-    return Promise.reject(err);
-  }
-  return Promise.resolve({ credentials: creds, subscriptions: subscriptionList });
+
+  const creds = new ApplicationTokenCredentials(clientId, domain, secret, options.tokenAudience, options.environment);
+  await creds.getToken();
+
+  const subscriptionList = await _getSubscriptions(creds, [domain], options.tokenAudience);
+
+  return { credentials: creds, subscriptions: subscriptionList };
 }
 
 /**
@@ -247,16 +239,13 @@ export async function withServicePrincipalCertificateWithAuthResponse(clientId: 
   if (!options.environment) {
     options.environment = Environment.AzureCloud;
   }
-  let creds: ApplicationTokenCertificateCredentials;
-  let subscriptionList: LinkedSubscription[] = [];
-  try {
-    creds = ApplicationTokenCertificateCredentials.create(clientId, certificateStringOrFilePath, domain, options);
-    await creds.getToken();
-    subscriptionList = await _getSubscriptions(creds, [domain], options.tokenAudience);
-  } catch (err) {
-    return Promise.reject(err);
-  }
-  return Promise.resolve({ credentials: creds, subscriptions: subscriptionList });
+
+  const creds = ApplicationTokenCertificateCredentials.create(clientId, certificateStringOrFilePath, domain, options);
+  await creds.getToken();
+
+  const subscriptionList = await _getSubscriptions(creds, [domain], options.tokenAudience);
+
+  return { credentials: creds, subscriptions: subscriptionList };
 }
 
 function validateAuthFileContent(credsObj: any, filePath: string) {
@@ -337,17 +326,14 @@ export async function withAuthFileWithAuthResponse(options?: LoginWithAuthFileOp
   const subscriptionEnvVariableName = options.subscriptionEnvVariableName || "AZURE_SUBSCRIPTION_ID";
   if (!filePath) {
     const msg = `Either provide an absolute file path to the auth file or set/export the environment variable - ${AuthConstants.AZURE_AUTH_LOCATION}.`;
-    return Promise.reject(new Error(msg));
+    throw new Error(msg);
   }
   let content: string, credsObj: any = {};
   const optionsForSp: any = {};
-  try {
-    content = readFileSync(filePath, { encoding: "utf8" });
-    credsObj = JSON.parse(content);
-    validateAuthFileContent(credsObj, filePath);
-  } catch (err) {
-    return Promise.reject(err);
-  }
+
+  content = readFileSync(filePath, { encoding: "utf8" });
+  credsObj = JSON.parse(content);
+  validateAuthFileContent(credsObj, filePath);
 
   if (!credsObj.managementEndpointUrl) {
     credsObj.managementEndpointUrl = credsObj.resourceManagerEndpointUrl;
@@ -473,8 +459,6 @@ export async function withInteractiveWithAuthResponse(options?: InteractiveLogin
   const authorityUrl: string = interactiveOptions.environment.activeDirectoryEndpointUrl + interactiveOptions.domain;
   const authContext = new adal.AuthenticationContext(authorityUrl, interactiveOptions.environment.validateAuthority, interactiveOptions.tokenCache);
   interactiveOptions.context = authContext;
-  let userCodeResponse: any;
-  let creds: DeviceTokenCredentials;
 
   function tryAcquireToken(interactiveOptions: InteractiveLoginOptions, resolve: any, reject: any) {
     authContext.acquireUserCode(interactiveOptions.tokenAudience!, interactiveOptions.clientId!, interactiveOptions.language!, (err: any, userCodeRes: adal.UserCodeInfo) => {
@@ -484,47 +468,52 @@ export async function withInteractiveWithAuthResponse(options?: InteractiveLogin
             tryAcquireToken(interactiveOptions, resolve, reject);
           }, 1000);
         } else {
-          return reject(err);
+          reject(err);
         }
+
+        return;
       }
-      userCodeResponse = userCodeRes;
+
       if (interactiveOptions.userCodeResponseLogger) {
-        interactiveOptions.userCodeResponseLogger(userCodeResponse.message);
+        interactiveOptions.userCodeResponseLogger(userCodeRes.message);
       } else {
-        console.log(userCodeResponse.message);
+        console.log(userCodeRes.message);
       }
-      return resolve(userCodeResponse);
+
+      return resolve(userCodeRes);
     });
   }
 
-  const getUserCode = new Promise<any>((resolve, reject) => {
+  const getUserCode = new Promise<adal.UserCodeInfo>((resolve, reject) => {
     return tryAcquireToken(interactiveOptions, resolve, reject);
   });
 
-  return getUserCode.then(() => {
-    return new Promise<DeviceTokenCredentials>((resolve, reject) => {
-      return authContext.acquireTokenWithDeviceCode(interactiveOptions.tokenAudience, interactiveOptions.clientId, userCodeResponse, (error: Error, tokenResponse: any) => {
-        if (error) {
-          return reject(error);
-        }
-        interactiveOptions.userName = tokenResponse.userId;
-        interactiveOptions.authorizationScheme = tokenResponse.tokenType;
-        try {
-          creds = new DeviceTokenCredentials(interactiveOptions.clientId, interactiveOptions.domain, interactiveOptions.userName,
-            interactiveOptions.tokenAudience, interactiveOptions.environment, interactiveOptions.tokenCache);
-        } catch (err) {
-          return reject(err);
-        }
-        return resolve(creds);
-      });
+  const userCodeResponse = await getUserCode;
+  const creds = await new Promise<DeviceTokenCredentials>((resolve, reject) => {
+    return authContext.acquireTokenWithDeviceCode(interactiveOptions.tokenAudience, interactiveOptions.clientId, userCodeResponse, (error, tokenResponse) => {
+      if (error) {
+        return reject(error);
+      }
+
+      const response = tokenResponse as adal.TokenResponse;
+      interactiveOptions.userName = response.userId;
+      interactiveOptions.authorizationScheme = response.tokenType;
+
+      let creds;
+      try {
+        creds = new DeviceTokenCredentials(interactiveOptions.clientId, interactiveOptions.domain, interactiveOptions.userName,
+          interactiveOptions.tokenAudience, interactiveOptions.environment, interactiveOptions.tokenCache);
+      } catch (err) {
+        return reject(err);
+      }
+      return resolve(creds);
     });
-  }).then((creds) => {
-    return buildTenantList(creds);
-  }).then((tenants) => {
-    return _getSubscriptions(creds, tenants, interactiveOptions.tokenAudience);
-  }).then((subscriptions) => {
-    return Promise.resolve({ credentials: creds, subscriptions: subscriptions });
   });
+
+  const tenants = await buildTenantList(creds);
+  const subscriptions = await _getSubscriptions(creds, tenants, interactiveOptions.tokenAudience);
+
+  return { credentials: creds, subscriptions: subscriptions };
 }
 
 /**
@@ -572,9 +561,7 @@ export function withAuthFile(options?: LoginWithAuthFileOptions, callback?: { (e
   const cb = callback as Function;
   if (!callback) {
     return withAuthFileWithAuthResponse(options).then((authRes) => {
-      return Promise.resolve(authRes.credentials);
-    }).catch((err) => {
-      return Promise.reject(err);
+      return authRes.credentials;
     });
   } else {
     msRest.promiseToCallback(withAuthFileWithAuthResponse(options))((err: Error, authRes: AuthResponse) => {
@@ -626,9 +613,7 @@ export function interactive(options?: InteractiveLoginOptions, callback?: { (err
   const cb = callback as Function;
   if (!callback) {
     return withInteractiveWithAuthResponse(options).then((authRes) => {
-      return Promise.resolve(authRes.credentials);
-    }).catch((err) => {
-      return Promise.reject(err);
+      return authRes.credentials;
     });
   } else {
     msRest.promiseToCallback(withInteractiveWithAuthResponse(options))((err: Error, authRes: AuthResponse) => {
@@ -677,9 +662,7 @@ export function withServicePrincipalSecret(clientId: string, secret: string, dom
   const cb = callback as Function;
   if (!callback) {
     return withServicePrincipalSecretWithAuthResponse(clientId, secret, domain, options).then((authRes) => {
-      return Promise.resolve(authRes.credentials);
-    }).catch((err) => {
-      return Promise.reject(err);
+      return authRes.credentials;
     });
   } else {
     msRest.promiseToCallback(withServicePrincipalSecretWithAuthResponse(clientId, secret, domain, options))((err: Error, authRes: AuthResponse) => {
@@ -730,9 +713,7 @@ export function withServicePrincipalCertificate(clientId: string, certificateStr
   const cb = callback as Function;
   if (!callback) {
     return withServicePrincipalCertificateWithAuthResponse(clientId, certificateStringOrFilePath, domain, options).then((authRes) => {
-      return Promise.resolve(authRes.credentials);
-    }).catch((err) => {
-      return Promise.reject(err);
+      return authRes.credentials;
     });
   } else {
     msRest.promiseToCallback(withServicePrincipalCertificateWithAuthResponse(clientId, certificateStringOrFilePath, domain, options))((err: Error, authRes: AuthResponse) => {
@@ -783,9 +764,7 @@ export function withUsernamePassword(username: string, password: string, options
   const cb = callback as Function;
   if (!callback) {
     return withUsernamePasswordWithAuthResponse(username, password, options).then((authRes) => {
-      return Promise.resolve(authRes.credentials);
-    }).catch((err) => {
-      return Promise.reject(err);
+      return authRes.credentials;
     });
   } else {
     msRest.promiseToCallback(withUsernamePasswordWithAuthResponse(username, password, options))((err: Error, authRes: AuthResponse) => {
@@ -821,20 +800,14 @@ function _getSubscriptions(
  * @param {string} [options.aadEndpoint] - The add endpoint for authentication. default - "https://login.microsoftonline.com"
  * @param {any} callback - the callback function.
  */
-function _withMSI(options?: MSIVmOptions): Promise<MSIVmTokenCredentials> {
+async function _withMSI(options?: MSIVmOptions): Promise<MSIVmTokenCredentials> {
   if (!options) {
     options = {};
   }
 
-  return new Promise((resolve, reject) => {
-    const creds = new MSIVmTokenCredentials(options);
-    creds.getToken().then((_tokenResponse) => {
-      // We ignore the token response, it's put in the cache.
-      return resolve(creds);
-    }).catch(error => {
-      reject(error);
-    });
-  });
+  const creds = new MSIVmTokenCredentials(options);
+  await creds.getToken();
+  return creds;
 }
 
 /**
@@ -898,20 +871,14 @@ export function loginWithVmMSI(options?: MSIVmOptions | Callback<MSIVmTokenCrede
 /**
  * Private method
  */
-function _withAppServiceMSI(options: MSIAppServiceOptions): Promise<MSIAppServiceTokenCredentials> {
+async function _withAppServiceMSI(options: MSIAppServiceOptions): Promise<MSIAppServiceTokenCredentials> {
   if (!options) {
     options = {};
   }
 
-  return new Promise((resolve, reject) => {
-    const creds = new MSIAppServiceTokenCredentials(options);
-    creds.getToken().then((_tokenResponse) => {
-      // We ignore the token response, it's put in the cache.
-      return resolve(creds);
-    }).catch(error => {
-      reject(error);
-    });
-  });
+  const creds = new MSIAppServiceTokenCredentials(options);
+  await creds.getToken();
+  return creds;
 }
 
 /**

--- a/lib/subscriptionManagement/subscriptionUtils.ts
+++ b/lib/subscriptionManagement/subscriptionUtils.ts
@@ -78,7 +78,7 @@ export interface LinkedSubscription {
  */
 export async function buildTenantList(credentials: TokenCredentialsBase, apiVersion = "2016-06-01"): Promise<string[]> {
   if (credentials.domain && credentials.domain !== AuthConstants.AAD_COMMON_TENANT) {
-    return Promise.resolve([credentials.domain]);
+    return [credentials.domain];
   }
 
   const client = new msRest.ServiceClient(credentials);
@@ -88,18 +88,13 @@ export async function buildTenantList(credentials: TokenCredentialsBase, apiVers
     url: reqUrl,
     method: "GET",
   };
-  let res: msRest.HttpOperationResponse;
-  try {
-    res = await client.sendRequest(req);
-  } catch (err) {
-    return Promise.reject(err);
-  }
+  const res = await client.sendRequest(req);
   const result: string[] = [];
   const tenants: any = res.parsedBody;
   for (const tenant in tenants.value) {
     result.push((<any>tenant).tenantId);
   }
-  return Promise.resolve(result);
+  return result;
 }
 
 export async function getSubscriptionsFromTenants(credentials: TokenCredentialsBase, tenantList: string[], apiVersion = "2016-06-01"): Promise<LinkedSubscription[]> {
@@ -122,13 +117,8 @@ export async function getSubscriptionsFromTenants(credentials: TokenCredentialsB
       url: reqUrl,
       method: "GET",
     };
-    let res: msRest.HttpOperationResponse;
-    try {
-      res = await client.sendRequest(req);
-    } catch (err) {
-      return Promise.reject(err);
-    }
 
+    const res = await client.sendRequest(req);
     const subscriptionList: any[] = (<any>res.parsedBody).value;
     subscriptions = subscriptions.concat(subscriptionList.map((s: any) => {
       s.tenantId = tenant;
@@ -144,5 +134,5 @@ export async function getSubscriptionsFromTenants(credentials: TokenCredentialsB
   }
   // Reset the original domain.
   credentials.domain = originalDomain;
-  return Promise.resolve(subscriptions);
+  return subscriptions;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
This cleans up a bunch of misunderstandings between `async` functions and `Promise`s.

* There is no need to catch exceptions inside async functions and return them wrapped via `Promise.reject`. This will happen automatically if an exception is thrown inside an async function.

* There is no need to wrap return values of async functions with `Promise.resolve`. This will happen automatically.

These changes make the code easier to read and understand, and remove unneccessary overhead.

There's also a few other commits in here that clean up some of the code.