### PR TITLE
Fix bug preventing any tenants from being discovered

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.2 - 2019/08/16
+- Fix bug prevent tenant IDs from being discovered on auth
+
 ## 3.0.1 - 2019/08/06
 - Reduce number of `Promise` object allocations inside `async` functions.
 

--- a/lib/subscriptionManagement/subscriptionUtils.ts
+++ b/lib/subscriptionManagement/subscriptionUtils.ts
@@ -91,8 +91,8 @@ export async function buildTenantList(credentials: TokenCredentialsBase, apiVers
   const res = await client.sendRequest(req);
   const result: string[] = [];
   const tenants: any = res.parsedBody;
-  for (const tenant in tenants.value) {
-    result.push((<any>tenant).tenantId);
+  for (const tenant of tenants.value) {
+    result.push(tenant.tenantId);
   }
   return result;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
Which in turns prevents any subscriptions in turn from being discovered which in turn makes auth very not useful.