### PR TITLE
Fix callback not calling issue in applicationTokenCredentialsBase.ts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.2 - 2019/08/22
+
+- Fixed a bug where the callback to `loginWithServicePrincipalSecretWithAuthResponse` is sometimes not called.
+
 ## 3.0.2 - 2019/08/16
 - Fix bug prevent tenant IDs from being discovered on auth
 
@@ -27,7 +31,7 @@
 
 ## 2.0.0 - 2019/05/20
 - Added support for client_id, object_id and ms_res_id query parameters for VmMSI. Fixes [#58](https://github.com/Azure/ms-rest-nodeauth/issues/58).
-- **Breaking change:** 
+- **Breaking change:**
   - Added support to get token for a different resource like Azure Keyvault, Azure Batch, Azure Graph apart from the default Azure Resource Manager resource via `AzureCliCredentials`.
   - `AzureCliCredentials.create()` now takes an optional parameter where the user can specify the subscriptionId and the resource for which the token is required.
   - `AzureCliCredentials.getDefaultSubscription()` has been changed to `AzureCliCredentials.getSubscription(subscriptionIdOrName?: string)`.

--- a/lib/credentials/applicationTokenCredentialsBase.ts
+++ b/lib/credentials/applicationTokenCredentialsBase.ts
@@ -78,13 +78,11 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
         }
 
         if (entries && entries.length > 0) {
-          return new Promise(resolve => {
-            return self.tokenCache.remove(entries, (err: Error) => {
-              if (err) {
-                return resolve({ result: false, details: err });
-              }
-              return resolve({ result: true });
-            });
+          return self.tokenCache.remove(entries, (err: Error) => {
+            if (err) {
+              return resolve({ result: false, details: err });
+            }
+            return resolve({ result: true });
           });
         } else {
           return resolve({ result: true });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
When calling "loginWithServicePrincipalSecretWithAuthResponse", the callback function is sometimes not called because a nested promise with parameter "resolve" hides the same parameter name in outer promise in applicationTokenCredentialsBase.ts. 

This bug is blocking our autorest generated SDK (typescript code) to run. Since the generated code depends on ms-rest-js@1.8.1, we cannot consume ms-rest-nodeauth@3.0.0 or higher. The fix should be based on ms-rest-nodeauth@2.0.4 and probably we need a new package with version 2.0.5 published in npm public server, to get our code working.