### PR TITLE
Add clientid param to MSIAppServiceOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ msRestNodeAuth.loginWithAuthFileWithAuthResponse(options).then((authRes) => {
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 
 const options: msRestNodeAuth.MSIVmOptions = {
-  port: 50342;
+  port: 50342,
 }
 
 msRestNodeAuth.loginWithVmMSI(options).then((msiTokenRes) => {
@@ -134,7 +134,7 @@ msRestNodeAuth.loginWithVmMSI(options).then((msiTokenRes) => {
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 
 const options: msRestNodeAuth.MSIAppServiceOptions = {
-  msiEndpoint: "http://127.0.0.1:41741/MSI/token/";
+  clientId: "48f97062-a6f3-48ae-b05b-e6df3468c256",
 }
 
 msRestNodeAuth.loginWithAppServiceMSI(options).then((msiTokenRes) => {

--- a/lib/credentials/msiAppServiceTokenCredentials.ts
+++ b/lib/credentials/msiAppServiceTokenCredentials.ts
@@ -24,6 +24,11 @@ export interface MSIAppServiceOptions extends MSIOptions {
    * @property {string} [msiApiVersion] - The api-version of the local MSI agent. Default value is "2017-09-01".
    */
   msiApiVersion?: string;
+  /**
+   * @property {string} [clientId] - The clientId of the managed identity you would like the token for. Required, if
+   * your app service has user-assigned managed identities.
+   */
+  clientId?: string;
 }
 
 /**
@@ -46,6 +51,11 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
    * @property {string} [msiApiVersion] The api-version of the local MSI agent. Default value is "2017-09-01".
    */
   msiApiVersion?: string;
+  /**
+   * @property {string} [clientId] - The clientId of the managed identity you would like the token for. Required, if
+   * your app service has user-assigned managed identities.
+   */
+  clientId?: string;
 
   /**
    * Creates an instance of MSIAppServiceTokenCredentials.
@@ -60,6 +70,8 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
    * - resource management endpoint "https://management.azure.com/" (default)
    * - management endpoint "https://management.core.windows.net/"
    * @param {string} [options.msiApiVersion] - The api-version of the local MSI agent. Default value is "2017-09-01".
+   * @param {string} [options.clientId] - The clientId of the managed identity you would like the token for. Required, if
+   * your app service has user-assigned managed identities.
    */
   constructor(options?: MSIAppServiceOptions) {
     if (!options) options = {};
@@ -85,6 +97,7 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
     this.msiEndpoint = options.msiEndpoint;
     this.msiSecret = options.msiSecret;
     this.msiApiVersion = options.msiApiVersion;
+    this.clientId = options.clientId;
   }
 
   /**
@@ -111,14 +124,17 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
 
   protected prepareRequestOptions(): WebResource {
     const endpoint = this.msiEndpoint.endsWith("/") ? this.msiEndpoint : `${this.msiEndpoint}/`;
-    const resource = encodeURIComponent(this.resource);
-    const getUrl = `${endpoint}?resource=${resource}&api-version=${this.msiApiVersion}`;
     const reqOptions: RequestPrepareOptions = {
-      url: getUrl,
+      url: endpoint,
       headers: {
-        "secret": this.msiSecret
+        secret: this.msiSecret,
       },
-      method: "GET"
+      queryParameters: {
+        "resource": this.resource,
+        "api-version": this.msiApiVersion,
+        "clientid": this.clientId,
+      },
+      method: "GET",
     };
 
     const webResource = new WebResource();

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3"
+    "typescript": "~3.5.3"
   },
   "homepage": "https://github.com/Azure/ms-rest-nodeauth",
   "repository": {


### PR DESCRIPTION
Fixes #79, allows for a clientid param to be provided to `MSIAppServiceOptions` so that code in App Service may generate credentials using a user-assigned managed identity.

Usage of `WebResource.prepare` within `prepareRequestOptions` has been mimicked from [#59](https://github.com/Azure/ms-rest-nodeauth/pull/59/files#diff-ef7041f1621d29386b2a2ed0db058220) for consistency. Structure of headers/params in the request has been based on the [app-service/overview-managed-identity](https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=dotnet#using-the-rest-protocol) page.