### PR TITLE
[Issue 89] Changing withAuthFileWithAuthResponse to re-authenticate for each tenant to return all the subscriptions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.4 - 2020/05/19
+
+- Fixed a [bug](https://github.com/Azure/ms-rest-nodeauth/issues/89) where `interactiveLoginWithAuthResponse` would not return organizations for Azure accounts outside of organizations.
+
 ## 3.0.2 - 2019/08/22
 
 - Fixed a bug where the callback to `loginWithServicePrincipalSecretWithAuthResponse` is sometimes not called.

--- a/lib/credentials/msiTokenCredentials.ts
+++ b/lib/credentials/msiTokenCredentials.ts
@@ -116,7 +116,7 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
       if (typeof parsedBody["expires_on"] === "string") {
         // possibly a Date string '09/14/2017 00:00:00 PM +00:00'
         if (parsedBody["expires_on"].includes(":") || parsedBody["expires_on"].includes("/")) {
-          parsedBody.expiresOn = new Date(parsedBody["expires_on"], 10);
+          parsedBody.expiresOn = new Date(Number(parsedBody["expires_on"]), 10);
         } else {
           // normal number as a string '1504130527'
           parsedBody.expiresOn = new Date(parseInt(parsedBody["expires_on"], 10));

--- a/lib/credentials/tokenCredentialsBase.ts
+++ b/lib/credentials/tokenCredentialsBase.ts
@@ -8,7 +8,7 @@ import { TokenClientCredentials } from "./tokenClientCredentials";
 import { TokenResponse, AuthenticationContext, MemoryCache, ErrorResponse, TokenCache } from "adal-node";
 
 export abstract class TokenCredentialsBase implements TokenClientCredentials {
-  public readonly authContext: AuthenticationContext;
+  private _authContext?: AuthenticationContext;
 
   public constructor(
     public readonly clientId: string,
@@ -30,8 +30,17 @@ export abstract class TokenCredentialsBase implements TokenClientCredentials {
         It must be the actual tenant (preferrably a string in a guid format)."}`);
     }
 
+    this.setDomain(domain);
+  }
+
+  get authContext(): AuthenticationContext {
+    return this._authContext!;
+  }
+
+  public setDomain(domain: string): void {
+    this.domain = domain;
     const authorityUrl = this.environment.activeDirectoryEndpointUrl + this.domain;
-    this.authContext = new AuthenticationContext(authorityUrl, this.environment.validateAuthority, this.tokenCache);
+    this._authContext = new AuthenticationContext(authorityUrl, this.environment.validateAuthority, this.tokenCache);
   }
 
   protected getActiveDirectoryResourceId(): string {

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -509,7 +509,15 @@ export async function withInteractiveWithAuthResponse(options?: InteractiveLogin
   });
 
   const tenants = await buildTenantList(creds);
-  const subscriptions = await _getSubscriptions(creds, tenants, interactiveOptions.tokenAudience);
+  let subscriptions: LinkedSubscription[] = [];
+
+  for (const tenant of tenants) {
+    creds.setDomain(tenant);
+    subscriptions = [
+      ...subscriptions,
+      ...await _getSubscriptions(creds, tenants, interactiveOptions.tokenAudience)
+    ];
+  }
 
   return { credentials: creds, subscriptions: subscriptions };
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
Issue [89](https://github.com/Azure/ms-rest-nodeauth/issues/89) shows that `interactiveLoginWithAuthResponse` is not returning any subscription for personal accounts with one or more tenants. This issue is not perceivable until the code explicitly calls to `_getSubscriptions`, which returns an empty array for those cases.

Upon investigation, a possible solution was to call `interactiveLoginWithAuthResponse` again with one of the received tenants from a previous execution of the same function as the `domain` parameter of this new call.

Another alternative seemed to set `organizations` as the domain, which should work in the v2.0 of the OAuth2 authentication workflow, as described in:

> The `{tenant}` value in the path of the request can be used to control who can sign into the application. The allowed values are `common`, `organizations`, `consumers`, and tenant identifiers. For more detail, see protocol basics.
> ([Source](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow))

However, passing in `organizations` as the domain causes the network requests to answer with status code 400. This is likely because `ms-rest-nodeauth` is using v1.0 of the API (`adal-node` specifically uses version 1.0 by default: https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/blob/dev/lib/oauth2client.js#L73).

Assuming a change of OAuth API version is out of the table, the repeated authentication approach could be narrowed down to a modification of `withInteractiveWithAuthResponse`, in which after retrieving the tenants, we could re-generate the credentials from `adal-node` to retrieve the subscriptions. For example: in `lib/login.ts`, in `withInteractiveWithAuthResponse`:

```ts
  let creds = await new Promise<DeviceTokenCredentials>((resolve, reject) => {
    // ...
      try {
        creds = new DeviceTokenCredentials(
          // ...
          interactiveOptions.domain, // <-- What we want to change
          // ...
        );
      } catch (err) {
    // ...
  });

  const tenants = await buildTenantList(creds);

  creds = await new Promise<DeviceTokenCredentials>((resolve, reject) => {
    // ...
      try {
        creds = new DeviceTokenCredentials(
          // ...
          tenants[0], // <-- What we changed
          // ...
        );
      } catch (err) {
    // ...
  });
```

That change in the domain parameter could also be done by altering the `DeviceTokenCredentials`'s parent class, `TokenCredentialsBase` to allow setting this domain internally, by extracting this functionality from the constructor into a public function and changing `_authContext` to be a private property:

```ts
export abstract class TokenCredentialsBase implements TokenClientCredentials {
  private _authContext?: AuthenticationContext;

  public constructor(/* ... */) {
    // ...
    this.setDomain(domain);
  }

  get authContext(): AuthenticationContext {
    return this._authContext!;
  }

  public setDomain(domain: string): void {
    this.domain = domain;
    const authorityUrl = this.environment.activeDirectoryEndpointUrl + this.domain;
    this._authContext = new AuthenticationContext(authorityUrl, this.environment.validateAuthority, this.tokenCache);
  }
```

With that in hand, and to overcome the limit of just one tenant, we decided to loop over the tenants, fetch the organizations and concatenate them into a single array, with the following code at the end of `withInteractiveWithAuthResponse`:

```ts
  const tenants = await buildTenantList(creds);
  let subscriptions: LinkedSubscription[] = [];

  for (const tenant of tenants) {
    creds.setDomain(tenant);
    subscriptions = [
      ...subscriptions,
      ...await _getSubscriptions(creds, tenants, interactiveOptions.tokenAudience)
    ];
  }

  return { credentials: creds, subscriptions: subscriptions };
```

This code makes ADAL do a new request to refresh the token for each tenant we work with. The logs from ADAL can be seen here:

- Relevant ADAL logs before the change: https://gist.githubusercontent.com/sadasant/430cf03f08182d298ec9c41a7805cde3/raw/c0397579b5583d454a27313072bc658b86771a26/no-change-authentication
- Relevant ADAL logs after the change, where it shows that a new token is requested and received, which will happen once for each tenant received with this change: https://gist.githubusercontent.com/sadasant/430cf03f08182d298ec9c41a7805cde3/raw/c0397579b5583d454a27313072bc658b86771a26/authentication-after-changing-the-domain

These logs were produced by using `adal-node`'s `Logging`:

```ts
Logging.setLoggingOptions({
  log: function(level, message, error) {
    console.log({ level, message, error });
  },
  level: 3,
  loggingWithPII: false  // Whether to log personal identification information.
});
```

If after feedback this PR happens to get approved, the following is true:

Fixes #89 