### PR TITLE
Make buildTenantsList more resilient to error responses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.6 - 2020/09/24
+
+- Fixed a bug where `buildTenantsList` will throw an error when it can't list tenants
+- Added instructions for authenticating with an existing token
+
 ## 2.0.5 - 2019/08/22
 - Fixed a bug where the callback to `loginWithServicePrincipalSecretWithAuthResponse` is sometimes not called.
 - Fix bug prevent tenant IDs from being discovered on auth

--- a/README.md
+++ b/README.md
@@ -200,6 +200,26 @@ function getUrl(subscriptionId: string): string {
 main();
 ```
 
+### Authenticating with an existing token
+
+If you have acquired a valid Azure Active Directory token from another source, you can use it to authenticate with Azure SDK libraries using the following code snippet:
+
+```js
+const { HttpHeaders } = require("@azure/ms-rest-js");
+
+function getCredentialForToken(accessToken) {
+  return {
+    signRequest: (request) => {
+      if (!request.headers) request.headers = new HttpHeaders();
+      request.headers.set("Authorization", `Bearer ${accessToken}`);
+      return Promise.resolve(request);
+    }
+  };
+}
+
+const creds = getCredentialForToken("your existing token");
+```
+
 ### Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/lib/credentials/msiTokenCredentials.ts
+++ b/lib/credentials/msiTokenCredentials.ts
@@ -116,7 +116,7 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
       if (typeof parsedBody["expires_on"] === "string") {
         // possibly a Date string '09/14/2017 00:00:00 PM +00:00'
         if (parsedBody["expires_on"].includes(":") || parsedBody["expires_on"].includes("/")) {
-          parsedBody.expiresOn = new Date(parsedBody["expires_on"], 10);
+          parsedBody.expiresOn = new Date(parsedBody["expires_on"]);
         } else {
           // normal number as a string '1504130527'
           parsedBody.expiresOn = new Date(parseInt(parsedBody["expires_on"], 10));

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -173,10 +173,14 @@ export async function withUsernamePasswordWithAuthResponse(username: string, pas
   }
 
   const creds = new UserTokenCredentials(options.clientId, options.domain, username, password, options.tokenAudience, options.environment);
-  await creds.getToken();
+  const tokenResponse = await creds.getToken();
 
   // The token cache gets propulated for all the tenants as a part of building the tenantList.
-  const tenantList = await buildTenantList(creds);
+  let tenantList = await buildTenantList(creds);
+  if (tenantList.length === 0 && tokenResponse.tenantId) {
+    tenantList = [tokenResponse.tenantId];
+  }
+
   const subscriptionList: LinkedSubscription[] = await _getSubscriptions(creds, tenantList, options.tokenAudience);
 
   return { credentials: creds, subscriptions: subscriptionList };

--- a/lib/subscriptionManagement/subscriptionUtils.ts
+++ b/lib/subscriptionManagement/subscriptionUtils.ts
@@ -90,10 +90,14 @@ export async function buildTenantList(credentials: TokenCredentialsBase, apiVers
   };
   const res = await client.sendRequest(req);
   const result: string[] = [];
-  const tenants: any = res.parsedBody;
-  for (const tenant of tenants.value) {
-    result.push(tenant.tenantId);
+
+  if (res.status < 300) {
+    const tenants: any = res.parsedBody;
+    for (const tenant of tenants.value) {
+      result.push(tenant.tenantId);
+    }
   }
+
   return result;
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
This change fixes #81 which reports that `buildTenantsList` throws an error when attempting to list subscriptions.  The fix is to detect an error response and return an empty list instead.  I'm also fixing the `withUsernamePasswordWithAuthResponse` method so that we use the `tenantId` that gets returned by the token request when `buildTenantsList` returns an empty array.