### PR TITLE
fix: correctly pass through the `tokenCache` option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.8 - Unreleased
+- Pass user provided `tokenCache` option to `withUsernamePasswordWithAuthResponse` and `withServicePrincipalSecretWithAuthResponse` methods to the credentials being created.
+
 ## 3.0.7 - 2021/02/23
 - Updated doc comments on all exported members to follow TSDoc for better API reference documentation.
 

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -174,7 +174,7 @@ export async function withUsernamePasswordWithAuthResponse(username: string, pas
     options.environment = Environment.AzureCloud;
   }
 
-  const creds = new UserTokenCredentials(options.clientId, options.domain, username, password, options.tokenAudience, options.environment);
+  const creds = new UserTokenCredentials(options.clientId, options.domain, username, password, options.tokenAudience, options.environment, options.tokenCache);
   const tokenResponse = await creds.getToken();
 
   // The token cache gets propulated for all the tenants as a part of building the tenantList.
@@ -214,7 +214,7 @@ export async function withServicePrincipalSecretWithAuthResponse(clientId: strin
     options.environment = Environment.AzureCloud;
   }
 
-  const creds = new ApplicationTokenCredentials(clientId, domain, secret, options.tokenAudience, options.environment);
+  const creds = new ApplicationTokenCredentials(clientId, domain, secret, options.tokenAudience, options.environment, options.tokenCache);
   await creds.getToken();
 
   const subscriptionList = await _getSubscriptions(creds, [domain], options.tokenAudience);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
This makes the `tokenCache` option work correctly for `withServicePrincipalSecretWithAuthResponse` and `withUsernamePasswordWithAuthResponse`