### PR TITLE
Simplify API reference docs by following TSDoc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.0.7 - 2021/02/23
-- Updated doc comments on all exported members to follow TSDoc for better API reference documentations.
+- Updated doc comments on all exported members to follow TSDoc for better API reference documentation.
 
 ## 3.0.6 - 2020/09/25
 - Fixed a bug where `buildTenantsList` will throw an error when it can't list tenants

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.7 - 2021/02/12
+## 3.0.7 - 2021/02/16
 - Updated doc comments on all exported members to follow TSDoc for better API reference documentations.
 
 ## 3.0.6 - 2020/09/25

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.7 - 2021/02/16
+## 3.0.7 - 2021/02/23
 - Updated doc comments on all exported members to follow TSDoc for better API reference documentations.
 
 ## 3.0.6 - 2020/09/25

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.7 - 2021/02/12
+- Updated doc comments on all exported members to follow TSDoc for better API reference documentations.
+
 ## 3.0.6 - 2020/09/25
 - Fixed a bug where `buildTenantsList` will throw an error when it can't list tenants
 - Added instructions for authenticating with an existing token

--- a/lib/credentials/applicationTokenCertificateCredentials.ts
+++ b/lib/credentials/applicationTokenCertificateCredentials.ts
@@ -17,7 +17,7 @@ export class ApplicationTokenCertificateCredentials extends ApplicationTokenCred
    * Creates a new ApplicationTokenCredentials object.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for detailed instructions on creating an Azure Active Directory application.
-   * 
+   *
    * @param clientId - The active directory application client id.
    * @param domain - The domain or tenant id containing this application.
    * @param certificate - A PEM encoded certificate private key.

--- a/lib/credentials/applicationTokenCertificateCredentials.ts
+++ b/lib/credentials/applicationTokenCertificateCredentials.ts
@@ -17,15 +17,15 @@ export class ApplicationTokenCertificateCredentials extends ApplicationTokenCred
    * Creates a new ApplicationTokenCredentials object.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for detailed instructions on creating an Azure Active Directory application.
-   * @constructor
-   * @param {string} clientId The active directory application client id.
-   * @param {string} domain The domain or tenant id containing this application.
-   * @param {string} certificate A PEM encoded certificate private key.
-   * @param {string} thumbprint A hex encoded thumbprint of the certificate.
-   * @param {string} [tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+   * 
+   * @param clientId - The active directory application client id.
+   * @param domain - The domain or tenant id containing this application.
+   * @param certificate - A PEM encoded certificate private key.
+   * @param thumbprint - A hex encoded thumbprint of the certificate.
+   * @param tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
    * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferrably in a guid format).
-   * @param {Environment} [environment] The azure environment to authenticate with.
-   * @param {object} [tokenCache] The token cache. Default value is the MemoryCache object from adal.
+   * @param environment - The azure environment to authenticate with.
+   * @param tokenCache - The token cache. Default value is the MemoryCache object from adal.
    */
   public constructor(
     clientId: string,
@@ -50,7 +50,7 @@ export class ApplicationTokenCertificateCredentials extends ApplicationTokenCred
 
   /**
    * Tries to get the token from cache initially. If that is unsuccessfull then it tries to get the token from ADAL.
-   * @returns {Promise<TokenResponse>} A promise that resolves to TokenResponse and rejects with an Error.
+   * @returns A promise that resolves to TokenResponse and rejects with an Error.
    */
   public async getToken(): Promise<TokenResponse> {
     try {
@@ -87,7 +87,7 @@ export class ApplicationTokenCertificateCredentials extends ApplicationTokenCred
    * @param clientId  The active directory application client id also known as the SPN (ServicePrincipal Name).
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for an example.
-   * @param {string} certificateStringOrFilePath A PEM encoded certificate and private key OR an absolute filepath to the .pem file containing that information. For example:
+   * @param certificateStringOrFilePath - A PEM encoded certificate and private key OR an absolute filepath to the .pem file containing that information. For example:
    * - CertificateString: "-----BEGIN PRIVATE KEY-----\n<xxxxx>\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\n<yyyyy>\n-----END CERTIFICATE-----\n"
    * - CertificateFilePath: **Absolute** file path of the .pem file.
    * @param domain The domain or tenant id containing this application.

--- a/lib/credentials/applicationTokenCredentials.ts
+++ b/lib/credentials/applicationTokenCredentials.ts
@@ -13,7 +13,7 @@ export class ApplicationTokenCredentials extends ApplicationTokenCredentialsBase
    * Creates a new ApplicationTokenCredentials object.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for detailed instructions on creating an Azure Active Directory application.
-   * 
+   *
    * @param clientId - The active directory application client id.
    * @param domain - The domain or tenant id containing this application.
    * @param secret - The authentication secret for the application.

--- a/lib/credentials/applicationTokenCredentials.ts
+++ b/lib/credentials/applicationTokenCredentials.ts
@@ -13,14 +13,14 @@ export class ApplicationTokenCredentials extends ApplicationTokenCredentialsBase
    * Creates a new ApplicationTokenCredentials object.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for detailed instructions on creating an Azure Active Directory application.
-   * @constructor
-   * @param {string} clientId The active directory application client id.
-   * @param {string} domain The domain or tenant id containing this application.
-   * @param {string} secret The authentication secret for the application.
-   * @param {string} [tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+   * 
+   * @param clientId - The active directory application client id.
+   * @param domain - The domain or tenant id containing this application.
+   * @param secret - The authentication secret for the application.
+   * @param tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
    * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferrably in a guid format).
-   * @param {Environment} [environment] The azure environment to authenticate with.
-   * @param {object} [tokenCache] The token cache. Default value is the MemoryCache object from adal.
+   * @param environment - The azure environment to authenticate with.
+   * @param tokenCache - The token cache. Default value is the MemoryCache object from adal.
    */
   public constructor(
     clientId: string,
@@ -40,7 +40,7 @@ export class ApplicationTokenCredentials extends ApplicationTokenCredentialsBase
 
   /**
    * Tries to get the token from cache initially. If that is unsuccessfull then it tries to get the token from ADAL.
-   * @returns {Promise<TokenResponse>} A promise that resolves to TokenResponse and rejects with an Error.
+   * @returns A promise that resolves to TokenResponse and rejects with an Error.
    */
   public async getToken(): Promise<TokenResponse> {
     try {

--- a/lib/credentials/applicationTokenCredentialsBase.ts
+++ b/lib/credentials/applicationTokenCredentialsBase.ts
@@ -11,13 +11,13 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
    * Creates a new ApplicationTokenCredentials object.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for detailed instructions on creating an Azure Active Directory application.
-   * @constructor
-   * @param {string} clientId The active directory application client id.
-   * @param {string} domain The domain or tenant id containing this application.
-   * @param {string} [tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+   * 
+   * @param clientId - The active directory application client id.
+   * @param domain - The domain or tenant id containing this application.
+   * @param tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
    * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferrably in a guid format).
-   * @param {Environment} [environment] The azure environment to authenticate with.
-   * @param {object} [tokenCache] The token cache. Default value is the MemoryCache object from adal.
+   * @param environment - The azure environment to authenticate with.
+   * @param tokenCache - The token cache. Default value is the MemoryCache object from adal.
    */
   public constructor(
     clientId: string,
@@ -64,8 +64,8 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
    * Rather we resolve with an object that says the result is false and error information is provided in
    * the details property of the resolved object. This is done to do better error handling in the above function
    * where removeInvalidItemsFromCache() is called.
-   * @param {object} query The query to be used for finding the token for service principal from the cache
-   * @returns {result: boolean, details?: Error} resultObject with more info.
+   * @param query - The query to be used for finding the token for service principal from the cache
+   * @returns resultObject with more info.
    */
   private removeInvalidItemsFromCache(
     query: object

--- a/lib/credentials/applicationTokenCredentialsBase.ts
+++ b/lib/credentials/applicationTokenCredentialsBase.ts
@@ -11,7 +11,7 @@ export abstract class ApplicationTokenCredentialsBase extends TokenCredentialsBa
    * Creates a new ApplicationTokenCredentials object.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for detailed instructions on creating an Azure Active Directory application.
-   * 
+   *
    * @param clientId - The active directory application client id.
    * @param domain - The domain or tenant id containing this application.
    * @param tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.

--- a/lib/credentials/azureCliCredentials.ts
+++ b/lib/credentials/azureCliCredentials.ts
@@ -118,7 +118,7 @@ export class AzureCliCredentials implements TokenClientCredentials {
   /**
    * Tries to get the new token from Azure CLI, if the token has expired or the subscription has
    * changed else uses the cached accessToken.
-   * @return The tokenResponse (tokenType and accessToken are the two important properties).
+   * @returns The tokenResponse (tokenType and accessToken are the two important properties).
    */
   public async getToken(): Promise<TokenResponse> {
     if (this._hasTokenExpired() || this._hasSubscriptionChanged() || this._hasResourceChanged()) {

--- a/lib/credentials/deviceTokenCredentials.ts
+++ b/lib/credentials/deviceTokenCredentials.ts
@@ -17,16 +17,16 @@ export class DeviceTokenCredentials extends TokenCredentialsBase {
    * When this credential is used, the script will provide a url and code. The user needs to copy the url and the code, paste it
    * in a browser and authenticate over there. If successful, the script will get the access token.
    *
-   * @constructor
-   * @param {string} [clientId] The active directory application client id.
-   * @param {string} [domain] The domain or tenant id containing this application. Default value is "common"
-   * @param {string} [username] The user name for account in the form: "user@example.com".
-   * @param {string} [tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+   * 
+   * @param clientId - The active directory application client id.
+   * @param domain - The domain or tenant id containing this application. Default value is "common"
+   * @param username - The user name for account in the form: "user@example.com".
+   * @param tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
    * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferrably in a guid format).
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for an example.
-   * @param {Environment} [environment] The azure environment to authenticate with. Default environment is "Azure" popularly known as "Public Azure Cloud".
-   * @param {object} [tokenCache] The token cache. Default value is the MemoryCache object from adal.
+   * @param environment - The azure environment to authenticate with. Default environment is "Azure" popularly known as "Public Azure Cloud".
+   * @param tokenCache - The token cache. Default value is the MemoryCache object from adal.
    */
   public constructor(
     clientId?: string,

--- a/lib/credentials/deviceTokenCredentials.ts
+++ b/lib/credentials/deviceTokenCredentials.ts
@@ -17,7 +17,7 @@ export class DeviceTokenCredentials extends TokenCredentialsBase {
    * When this credential is used, the script will provide a url and code. The user needs to copy the url and the code, paste it
    * in a browser and authenticate over there. If successful, the script will get the access token.
    *
-   * 
+   *
    * @param clientId - The active directory application client id.
    * @param domain - The domain or tenant id containing this application. Default value is "common"
    * @param username - The user name for account in the form: "user@example.com".

--- a/lib/credentials/msiAppServiceTokenCredentials.ts
+++ b/lib/credentials/msiAppServiceTokenCredentials.ts
@@ -5,66 +5,66 @@ import { MSITokenCredentials, MSIOptions, MSITokenResponse } from "./msiTokenCre
 import { RequestPrepareOptions, WebResource } from "@azure/ms-rest-js";
 
 /**
- * @interface MSIAppServiceOptions Defines the optional parameters for authentication with MSI for AppService.
+ * Defines the optional parameters for authentication with MSI for AppService.
  */
 export interface MSIAppServiceOptions extends MSIOptions {
   /**
-   * @property {string} [msiEndpoint] - The local URL from which your app can request tokens.
+   * The local URL from which your app can request tokens.
    * Unless this property is specified, any of the two environment variables `IDENTITY_ENDPOINT` or `MSI_ENDPOINT` will be used as the default value.
    */
   msiEndpoint?: string;
   /**
-   * @property {string} [msiSecret] - The secret used in communication between your code and the local MSI agent.
+   * The secret used in communication between your code and the local MSI agent.
    * Unless this property is specified, any of the two environment variables `IDENTITY_SECRET` or `MSI_SECRET` will be used as the default value.
    */
   msiSecret?: string;
   /**
-   * @property {string} [msiApiVersion] - The api-version of the local MSI agent. Default value is "2017-09-01".
+   * The api-version of the local MSI agent. Default value is "2017-09-01".
    */
   msiApiVersion?: string;
   /**
-   * @property {string} [clientId] - The clientId of the managed identity you would like the token for. Required, if
+   * The clientId of the managed identity you would like the token for. Required, if
    * your app service has user-assigned managed identities.
    */
   clientId?: string;
 }
 
 /**
- * @class MSIAppServiceTokenCredentials
+ * Provides information about managed service identity token credentials in an App Service environment.
  */
 export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
   /**
-   * @property {string} msiEndpoint - The local URL from which your app can request tokens.
+   * The local URL from which your app can request tokens.
    * Unless this property is specified, any of the two environment variables `IDENTITY_ENDPOINT` or `MSI_ENDPOINT` will be used as the default value.
    */
   msiEndpoint: string;
   /**
-   * @property {string} msiSecret - The secret used in communication between your code and the local MSI agent.
+   * The secret used in communication between your code and the local MSI agent.
    * Unless this property is specified, any of the two environment variables `IDENTITY_SECRET` or `MSI_SECRET` will be used as the default value.
    */
   msiSecret: string;
   /**
-   * @property {string} [msiApiVersion] The api-version of the local MSI agent. Default value is "2017-09-01".
+   * The api-version of the local MSI agent. Default value is "2017-09-01".
    */
   msiApiVersion?: string;
   /**
-   * @property {string} [clientId] - The clientId of the managed identity you would like the token for. Required, if
+   * The clientId of the managed identity you would like the token for. Required, if
    * your app service has user-assigned managed identities.
    */
   clientId?: string;
 
   /**
    * Creates an instance of MSIAppServiceTokenCredentials.
-   * @param {string} [options.msiEndpoint] - The local URL from which your app can request tokens.
+   * @param options.msiEndpoint - The local URL from which your app can request tokens.
    * Unless this property is specified, any of the two environment variables `IDENTITY_ENDPOINT` or `MSI_ENDPOINT` will be used as the default value.
-   * @param {string} [options.msiSecret] - The secret used in communication between your code and the local MSI agent.
+   * @param options.msiSecret - The secret used in communication between your code and the local MSI agent.
    * Unless this property is specified, any of the two environment variables `IDENTITY_SECRET` or `MSI_SECRET` will be used as the default value.
-   * @param {string} [options.resource] - The resource uri or token audience for which the token is needed.
+   * @param options.resource - The resource uri or token audience for which the token is needed.
    * For e.g. it can be:
    * - resource management endpoint "https://management.azure.com/" (default)
    * - management endpoint "https://management.core.windows.net/"
-   * @param {string} [options.msiApiVersion] - The api-version of the local MSI agent. Default value is "2017-09-01".
-   * @param {string} [options.clientId] - The clientId of the managed identity you would like the token for. Required, if
+   * @param options.msiApiVersion - The api-version of the local MSI agent. Default value is "2017-09-01".
+   * @param options.clientId - The clientId of the managed identity you would like the token for. Required, if
    * your app service has user-assigned managed identities.
    */
   constructor(options?: MSIAppServiceOptions) {
@@ -96,7 +96,7 @@ export class MSIAppServiceTokenCredentials extends MSITokenCredentials {
 
   /**
    * Prepares and sends a GET request to a service endpoint indicated by the app service, which responds with the access token.
-   * @return {Promise<MSITokenResponse>} Promise with the tokenResponse (tokenType and accessToken are the two important properties).
+   * @returns Promise with the tokenResponse (tokenType and accessToken are the two important properties).
    */
   async getToken(): Promise<MSITokenResponse> {
     const reqOptions = this.prepareRequestOptions();

--- a/lib/credentials/msiTokenCredentials.ts
+++ b/lib/credentials/msiTokenCredentials.ts
@@ -6,7 +6,7 @@ import { TokenClientCredentials, TokenResponse } from "./tokenClientCredentials"
 import { AuthConstants } from "../util/authConstants";
 
 /**
- * @interface MSIOptions Defines the optional parameters for authentication with MSI.
+ * Defines the optional parameters for authentication with MSI.
  */
 export interface MSIOptions {
   /**
@@ -21,24 +21,24 @@ export interface MSIOptions {
   resource?: string;
 
   /**
-   * @property {HttpClient} [httpClient] - The client responsible for sending HTTP requests.
+   * The client responsible for sending HTTP requests.
    * By default it is Axios-based {@link DefaultHttpClient}.
    */
   httpClient?: HttpClient;
 }
 
 /**
- * @interface MSITokenResponse - Describes the MSITokenResponse.
+ * Describes the MSITokenResponse.
  */
 export interface MSITokenResponse extends TokenResponse {
   /**
-   * @property {any} any - Placeholder for unknown properties.
+   * Placeholder for unknown properties.
    */
   readonly [x: string]: any;
 }
 
 /**
- * @class MSITokenCredentials - Provides information about managed service identity token credentials.
+ * Provides information about managed service identity token credentials.
  * This object can only be used to acquire token on a virtual machine provisioned in Azure with managed service identity.
  */
 export abstract class MSITokenCredentials implements TokenClientCredentials {
@@ -55,8 +55,8 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
 
   /**
    * Creates an instance of MSITokenCredentials.
-   * @param {object} [options] - Optional parameters
-   * @param {string} [options.resource] - The resource uri or token audience for which the token is needed.
+   * @param options - Optional parameters
+   * @param options.resource - The resource uri or token audience for which the token is needed.
    * For e.g. it can be:
    * - resource management endpoint "https://management.azure.com/"(default)
    * - management endpoint "https://management.core.windows.net/"
@@ -77,8 +77,8 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
   /**
    * Parses a tokenResponse json string into a object, and converts properties on the first level to camelCase.
    * This method tries to standardize the tokenResponse
-   * @param  {string} body  A json string
-   * @return {object} [tokenResponse] The tokenResponse (tokenType and accessToken are the two important properties).
+   * @param  body - A json string
+   * @returns The tokenResponse (tokenType and accessToken are the two important properties).
    */
   parseTokenResponse(body: string): TokenResponse {
     // Docs show different examples of possible MSI responses for different services. https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview
@@ -129,8 +129,8 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
 
   /**
    * Prepares and sends a POST request to a service endpoint hosted on the Azure VM, which responds with the access token.
-   * @param  {function} callback  The callback in the form (err, result)
-   * @return {Promise<MSITokenResponse>} Promise with the token response.
+   * @param  callback - The callback in the form (err, result)
+   * @returns Promise with the token response.
    */
   abstract async getToken(): Promise<MSITokenResponse>;
 
@@ -139,8 +139,8 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {webResource} The WebResource to be signed.
-   * @return {Promise<WebResource>} Promise with signed WebResource.
+   * @param The - WebResource to be signed.
+   * @returns Promise with signed WebResource.
    */
   public async signRequest(webResource: WebResource): Promise<WebResource> {
     const tokenResponse = await this.getToken();

--- a/lib/credentials/msiTokenCredentials.ts
+++ b/lib/credentials/msiTokenCredentials.ts
@@ -139,7 +139,7 @@ export abstract class MSITokenCredentials implements TokenClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param The - WebResource to be signed.
+   * @param webResource - The WebResource to be signed.
    * @returns Promise with signed WebResource.
    */
   public async signRequest(webResource: WebResource): Promise<WebResource> {

--- a/lib/credentials/msiVmTokenCredentials.ts
+++ b/lib/credentials/msiVmTokenCredentials.ts
@@ -5,11 +5,11 @@ import { MSITokenCredentials, MSIOptions, MSITokenResponse } from "./msiTokenCre
 import { RequestPrepareOptions, WebResource, URLBuilder, HttpMethods } from "@azure/ms-rest-js";
 
 /**
- * @interface MSIVmOptions Defines the optional parameters for authentication with MSI for Virtual Machine.
+ * Defines the optional parameters for authentication with MSI for Virtual Machine.
  */
 export interface MSIVmOptions extends MSIOptions {
   /**
-   * @property {string} [msiEndpoint] - Azure Instance Metadata Service identity endpoint.
+   * Azure Instance Metadata Service identity endpoint.
    *
    * The default and recommended endpoint is "http://169.254.169.254/metadata/identity/oauth2/token"
    * per https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
@@ -44,7 +44,7 @@ export interface MSIVmOptions extends MSIOptions {
 }
 
 /**
- * @class MSIVmTokenCredentials
+ * Provides information about managed service identity token credentials on a virtual machine provisioned in Azure.
  */
 export class MSIVmTokenCredentials extends MSITokenCredentials {
   msiEndpoint: string;
@@ -89,7 +89,7 @@ export class MSIVmTokenCredentials extends MSITokenCredentials {
 
   /**
    * Prepares and sends a POST request to a service endpoint hosted on the Azure VM, which responds with the access token.
-   * @return {Promise<MSITokenResponse>} Promise with the tokenResponse (tokenType and accessToken are the two important properties).
+   * @returns Promise with the tokenResponse (tokenType and accessToken are the two important properties).
    */
   async getToken(): Promise<MSITokenResponse> {
     const reqOptions = this.prepareRequestOptions();

--- a/lib/credentials/tokenCredentialsBase.ts
+++ b/lib/credentials/tokenCredentialsBase.ts
@@ -82,8 +82,7 @@ export abstract class TokenCredentialsBase implements TokenClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param The - WebResource to be signed.
-   * @param  - callback  The callback function.
+   * @param webResource - The WebResource to be signed.
    */
   public async signRequest(webResource: WebResource): Promise<WebResource> {
     const tokenResponse = await this.getToken();

--- a/lib/credentials/tokenCredentialsBase.ts
+++ b/lib/credentials/tokenCredentialsBase.ts
@@ -74,18 +74,16 @@ export abstract class TokenCredentialsBase implements TokenClientCredentials {
 
   /**
    * Tries to get the token from cache initially. If that is unsuccessful then it tries to get the token from ADAL.
-   * @returns {Promise<TokenResponse>}
-   * {object} [tokenResponse] The tokenResponse (tokenType and accessToken are the two important properties).
-   * @memberof TokenCredentialsBase
+   * 
+   * @returns The tokenResponse (tokenType and accessToken are the two important properties).
    */
   public async abstract getToken(): Promise<TokenResponse>;
 
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {webResource} The WebResource to be signed.
-   * @param {function(error)}  callback  The callback function.
-   * @return {undefined}
+   * @param The - WebResource to be signed.
+   * @param  - callback  The callback function.
    */
   public async signRequest(webResource: WebResource): Promise<WebResource> {
     const tokenResponse = await this.getToken();

--- a/lib/credentials/tokenCredentialsBase.ts
+++ b/lib/credentials/tokenCredentialsBase.ts
@@ -5,7 +5,13 @@ import { Constants as MSRestConstants, WebResource } from "@azure/ms-rest-js";
 import { Environment } from "@azure/ms-rest-azure-env";
 import { TokenAudience } from "../util/authConstants";
 import { TokenClientCredentials } from "./tokenClientCredentials";
-import { TokenResponse, AuthenticationContext, MemoryCache, ErrorResponse, TokenCache } from "adal-node";
+import {
+  TokenResponse,
+  AuthenticationContext,
+  MemoryCache,
+  ErrorResponse,
+  TokenCache,
+} from "adal-node";
 
 export abstract class TokenCredentialsBase implements TokenClientCredentials {
   public authContext: AuthenticationContext;
@@ -25,19 +31,34 @@ export abstract class TokenCredentialsBase implements TokenClientCredentials {
       throw new Error("domain must be a non empty string.");
     }
 
-    if (this.tokenAudience === "graph" && this.domain.toLowerCase() === "common") {
-      throw new Error(`${"If the tokenAudience is specified as \"graph\" then \"domain\" cannot be defaulted to \"common\" tenant.\
-        It must be the actual tenant (preferably a string in a guid format)."}`);
+    if (
+      this.tokenAudience === "graph" &&
+      this.domain.toLowerCase() === "common"
+    ) {
+      throw new Error(
+        `${'If the tokenAudience is specified as "graph" then "domain" cannot be defaulted to "common" tenant.\
+        It must be the actual tenant (preferably a string in a guid format).'}`
+      );
     }
 
-    const authorityUrl = this.environment.activeDirectoryEndpointUrl + this.domain;
-    this.authContext = new AuthenticationContext(authorityUrl, this.environment.validateAuthority, this.tokenCache);
+    const authorityUrl =
+      this.environment.activeDirectoryEndpointUrl + this.domain;
+    this.authContext = new AuthenticationContext(
+      authorityUrl,
+      this.environment.validateAuthority,
+      this.tokenCache
+    );
   }
 
   public setDomain(domain: string): void {
     this.domain = domain;
-    const authorityUrl = this.environment.activeDirectoryEndpointUrl + this.domain;
-    this.authContext = new AuthenticationContext(authorityUrl, this.environment.validateAuthority, this.tokenCache);
+    const authorityUrl =
+      this.environment.activeDirectoryEndpointUrl + this.domain;
+    this.authContext = new AuthenticationContext(
+      authorityUrl,
+      this.environment.validateAuthority,
+      this.tokenCache
+    );
   }
 
   protected getActiveDirectoryResourceId(): string {
@@ -58,26 +79,31 @@ export abstract class TokenCredentialsBase implements TokenClientCredentials {
     const resource = this.getActiveDirectoryResourceId();
 
     return new Promise<TokenResponse>((resolve, reject) => {
-      self.authContext.acquireToken(resource, username!, self.clientId, (error: Error, tokenResponse: TokenResponse | ErrorResponse) => {
-        if (error) {
-          return reject(error);
-        }
+      self.authContext.acquireToken(
+        resource,
+        username!,
+        self.clientId,
+        (error: Error, tokenResponse: TokenResponse | ErrorResponse) => {
+          if (error) {
+            return reject(error);
+          }
 
-        if (tokenResponse.error || tokenResponse.errorDescription) {
-          return reject(tokenResponse);
-        }
+          if (tokenResponse.error || tokenResponse.errorDescription) {
+            return reject(tokenResponse);
+          }
 
-        return resolve(tokenResponse as TokenResponse);
-      });
+          return resolve(tokenResponse as TokenResponse);
+        }
+      );
     });
   }
 
   /**
    * Tries to get the token from cache initially. If that is unsuccessful then it tries to get the token from ADAL.
-   * 
+   *
    * @returns The tokenResponse (tokenType and accessToken are the two important properties).
    */
-  public async abstract getToken(): Promise<TokenResponse>;
+  public abstract async getToken(): Promise<TokenResponse>;
 
   /**
    * Signs a request with the Authentication header.
@@ -86,7 +112,10 @@ export abstract class TokenCredentialsBase implements TokenClientCredentials {
    */
   public async signRequest(webResource: WebResource): Promise<WebResource> {
     const tokenResponse = await this.getToken();
-    webResource.headers.set(MSRestConstants.HeaderConstants.AUTHORIZATION, `${tokenResponse.tokenType} ${tokenResponse.accessToken}`);
+    webResource.headers.set(
+      MSRestConstants.HeaderConstants.AUTHORIZATION,
+      `${tokenResponse.tokenType} ${tokenResponse.accessToken}`
+    );
     return webResource;
   }
 }

--- a/lib/credentials/topicCredentials.ts
+++ b/lib/credentials/topicCredentials.ts
@@ -10,7 +10,7 @@ export class TopicCredentials extends ApiKeyCredentials {
   /**
    * Creates a new EventGrid TopicCredentials object.
    *
-   * 
+   *
    * @param topicKey -   The EventGrid topic key
    */
   constructor(topicKey: string) {

--- a/lib/credentials/topicCredentials.ts
+++ b/lib/credentials/topicCredentials.ts
@@ -10,8 +10,8 @@ export class TopicCredentials extends ApiKeyCredentials {
   /**
    * Creates a new EventGrid TopicCredentials object.
    *
-   * @constructor
-   * @param {string} topicKey   The EventGrid topic key
+   * 
+   * @param topicKey -   The EventGrid topic key
    */
   constructor(topicKey: string) {
     if (!topicKey || (topicKey && typeof topicKey !== "string")) {

--- a/lib/credentials/userTokenCredentials.ts
+++ b/lib/credentials/userTokenCredentials.ts
@@ -14,17 +14,17 @@ export class UserTokenCredentials extends TokenCredentialsBase {
   /**
    * Creates a new UserTokenCredentials object.
    *
-   * @constructor
-   * @param {string} clientId The active directory application client id.
+   * 
+   * @param clientId - The active directory application client id.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for an example.
-   * @param {string} domain The domain or tenant id containing this application.
-   * @param {string} username The user name for the Organization Id account.
-   * @param {string} password The password for the Organization Id account.
-   * @param {string} [tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+   * @param domain - The domain or tenant id containing this application.
+   * @param username - The user name for the Organization Id account.
+   * @param password - The password for the Organization Id account.
+   * @param tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
    * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
-   * @param {Environment} [environment] The azure environment to authenticate with.
-   * @param {object} [tokenCache] The token cache. Default value is the MemoryCache object from adal.
+   * @param environment - The azure environment to authenticate with.
+   * @param tokenCache - The token cache. Default value is the MemoryCache object from adal.
    */
   public constructor(
     clientId: string,
@@ -65,9 +65,8 @@ export class UserTokenCredentials extends TokenCredentialsBase {
 
   /**
    * Tries to get the token from cache initially. If that is unsuccessful then it tries to get the token from ADAL.
-   * @returns {Promise<TokenResponse>}
-   * {object} [tokenResponse] The tokenResponse (tokenType and accessToken are the two important properties).
-   * @memberof UserTokenCredentials
+   * 
+   * @returns The tokenResponse (tokenType and accessToken are the two important properties).
    */
   public async getToken(): Promise<TokenResponse> {
     try {

--- a/lib/credentials/userTokenCredentials.ts
+++ b/lib/credentials/userTokenCredentials.ts
@@ -14,7 +14,7 @@ export class UserTokenCredentials extends TokenCredentialsBase {
   /**
    * Creates a new UserTokenCredentials object.
    *
-   * 
+   *
    * @param clientId - The active directory application client id.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for an example.
@@ -65,7 +65,7 @@ export class UserTokenCredentials extends TokenCredentialsBase {
 
   /**
    * Tries to get the token from cache initially. If that is unsuccessful then it tries to get the token from ADAL.
-   * 
+   *
    * @returns The tokenResponse (tokenType and accessToken are the two important properties).
    */
   public async getToken(): Promise<TokenResponse> {

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -18,7 +18,7 @@ import { MSIAppServiceTokenCredentials, MSIAppServiceOptions } from "./credentia
 import { MSITokenResponse } from "./credentials/msiTokenCredentials";
 
 /**
- * @constant {Array<string>} managementPlaneTokenAudiences - Urls for management plane token
+ * Urls for management plane token
  * audience across different azure environments.
  */
 const managementPlaneTokenAudiences = [
@@ -54,80 +54,80 @@ if (process.env["AZURE_ADAL_LOGGING_ENABLED"]) {
 }
 
 /**
- * @interface AzureTokenCredentialsOptions - Describes optional parameters for servicePrincipal/secret authentication.
+ * Describes optional parameters for servicePrincipal/secret authentication.
  */
 export interface AzureTokenCredentialsOptions {
   /**
-   * @property {TokenAudience} [tokenAudience] - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+   * The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
    * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
    */
   tokenAudience?: TokenAudience;
   /**
-   * @property {AzureEnvironment} [environment] - The Azure environment to authenticate with.
+   * The Azure environment to authenticate with.
    */
   environment?: Environment;
   /**
-   * @property {TokenCache} [tokenCache] - The token cache. Default value is MemoryCache from adal.
+   * The token cache. Default value is MemoryCache from adal.
    */
   tokenCache?: adal.TokenCache;
 }
 
 /**
- * @interface LoginWithUsernamePasswordOptions - Describes optional parameters for username/password authentication.
+ * Describes optional parameters for username/password authentication.
  */
 export interface LoginWithUsernamePasswordOptions extends AzureTokenCredentialsOptions {
   /**
-   * @property {string} [clientId] - The active directory application client id.
+   * The active directory application client id.
    * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
    * for an example.
    */
   clientId?: string;
   /**
-   * @property {string} [domain] - The domain or tenant Id containing this application. Default value is "common".
+   * The domain or tenant Id containing this application. Default value is "common".
    */
   domain?: string;
 }
 
 /**
- * @interface InteractiveLoginOptions - Describes optional parameters for interactive authentication.
+ * Describes optional parameters for interactive authentication.
  */
 export interface InteractiveLoginOptions extends LoginWithUsernamePasswordOptions {
   /**
-   * @property {object|function} [userCodeResponseLogger] A logger that logs the user code response message required for interactive login. When
+   * A logger that logs the user code response message required for interactive login. When
    * this option is specified the usercode response message will not be logged to console.
    */
   userCodeResponseLogger?: any;
   /**
-   * @property {string} [language] The language code specifying how the message should be localized to. Default value "en-us".
+   * The language code specifying how the message should be localized to. Default value "en-us".
    */
   language?: string;
 }
 
 /**
- * @interface AuthResponse - Describes the authentication response.
+ * Describes the authentication response.
  */
 export interface AuthResponse {
   /**
-   *  @property {TokenCredentialsBase} credentials - The credentials object.
+   *  The credentials object.
    */
   credentials: TokenCredentialsBase;
   /**
-   * @property {Array<LinkedSubscription>} [subscriptions] List of associated subscriptions. It will be empty for personal accounts, unless the login method is called with a tenant Id sent as the `domain` optional parameter.
+   * List of associated subscriptions. It will be empty for personal accounts, unless the login method is called with a tenant Id sent as the `domain` optional parameter.
    */
   subscriptions?: LinkedSubscription[];
 }
 
 /**
- * @interface LoginWithAuthFileOptions - Describes optional parameters for login withAuthFile.
+ * Describes optional parameters for login withAuthFile.
  */
 export interface LoginWithAuthFileOptions {
   /**
-   * @property {string} [filePath] - Absolute file path to the auth file. If not provided
+   * Absolute file path to the auth file. If not provided
    * then please set the environment variable AZURE_AUTH_LOCATION.
    */
   filePath?: string;
   /**
-   * @property {string} [subscriptionEnvVariableName] - The subscriptionId environment variable
+   * The subscriptionId environment variable
    * name. Default is "AZURE_SUBSCRIPTION_ID".
    */
   subscriptionEnvVariableName?: string;
@@ -136,8 +136,8 @@ export interface LoginWithAuthFileOptions {
 /**
  * Generic callback type definition.
  *
- * @property {Error} error - The error occurred if any, while executing the request; otherwise undefined
- * @property {TResult} result - Result when call was successful.
+ * The error occurred if any, while executing the request; otherwise undefined
+ * Result when call was successful.
  */
 export type Callback<TResult> = (error?: Error, result?: TResult) => void;
 /**
@@ -146,19 +146,19 @@ export type Callback<TResult> = (error?: Error, result?: TResult) => void;
  *
  * When using personal accounts, the `domain` property in the `options` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {string} username The user name for the Organization Id account.
- * @param {string} password The password for the Organization Id account.
- * @param {object} [options] Object representing optional parameters.
- * @param {string} [options.clientId] The active directory application client id.
+ * @param username - The user name for the Organization Id account.
+ * @param password - The password for the Organization Id account.
+ * @param options - Object representing optional parameters.
+ * @param options.clientId - The active directory application client id.
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+ * @param options.tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
  * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
- * @param {string} [options.domain] The domain or tenant Id containing this application. Default value "common".
- * @param {Environment} [options.environment] The azure environment to authenticate with.
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
+ * @param options.domain - The domain or tenant Id containing this application. Default value "common".
+ * @param options.environment - The azure environment to authenticate with.
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
  *
- * @returns {Promise<AuthResponse>} A Promise that resolves to AuthResponse, which contains `credentials` and an optional `subscriptions` array, and rejects with an Error.
+ * @returns A Promise that resolves to AuthResponse, which contains `credentials` and an optional `subscriptions` array, and rejects with an Error.
  */
 export async function withUsernamePasswordWithAuthResponse(username: string, password: string, options?: LoginWithUsernamePasswordOptions): Promise<AuthResponse> {
   if (!options) {
@@ -193,18 +193,18 @@ export async function withUsernamePasswordWithAuthResponse(username: string, pas
  *
  * When using personal accounts, the `domain` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {string} clientId The active directory application client Id also known as the SPN (ServicePrincipal Name).
+ * @param clientId - The active directory application client Id also known as the SPN (ServicePrincipal Name).
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
- * @param {string} secret The application secret for the service principal.
- * @param {string} domain The domain or tenant Id containing this application.
- * @param {object} [options] Object representing optional parameters.
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+ * @param secret - The application secret for the service principal.
+ * @param domain - The domain or tenant Id containing this application.
+ * @param options - Object representing optional parameters.
+ * @param options.tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
  * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
- * @param {Environment} [options.environment] The azure environment to authenticate with.
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
+ * @param options.environment - The azure environment to authenticate with.
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
  *
- * @returns {Promise<AuthResponse>} A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
+ * @returns A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
  */
 export async function withServicePrincipalSecretWithAuthResponse(clientId: string, secret: string, domain: string, options?: AzureTokenCredentialsOptions): Promise<AuthResponse> {
   if (!options) {
@@ -227,20 +227,20 @@ export async function withServicePrincipalSecretWithAuthResponse(clientId: strin
  *
  * When using personal accounts, the `domain` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {string} clientId The active directory application client Id also known as the SPN (ServicePrincipal Name).
+ * @param clientId - The active directory application client Id also known as the SPN (ServicePrincipal Name).
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
- * @param {string} certificateStringOrFilePath A PEM encoded certificate and private key OR an absolute filepath to the .pem file containing that information. For example:
+ * @param certificateStringOrFilePath - A PEM encoded certificate and private key OR an absolute filepath to the .pem file containing that information. For example:
  * - CertificateString: "-----BEGIN PRIVATE KEY-----\n<xxxxx>\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\n<yyyyy>\n-----END CERTIFICATE-----\n"
  * - CertificateFilePath: **Absolute** file path of the .pem file.
- * @param {string} domain The domain or tenant Id containing this application.
- * @param {object} [options] Object representing optional parameters.
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+ * @param domain - The domain or tenant Id containing this application.
+ * @param options - Object representing optional parameters.
+ * @param options.tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
  * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
- * @param {Environment} [options.environment] The azure environment to authenticate with.
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
+ * @param options.environment - The azure environment to authenticate with.
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
  *
- * @returns {Promise<AuthResponse>} A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
+ * @returns A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
  */
 export async function withServicePrincipalCertificateWithAuthResponse(clientId: string, certificateStringOrFilePath: string, domain: string, options?: AzureTokenCredentialsOptions): Promise<AuthResponse> {
   if (!options) {
@@ -321,14 +321,14 @@ function foundManagementEndpointUrl(authFileUrl: string, envUrl: string): boolea
  * the subscriptionId from the auth file to the user provided environment variable in the options
  * parameter or the default "AZURE_SUBSCRIPTION_ID".
  *
- * @param {object} [options] - Optional parameters
- * @param {string} [options.filePath] - Absolute file path to the auth file. If not provided
+ * @param options - Optional parameters
+ * @param options.filePath - Absolute file path to the auth file. If not provided
  * then please set the environment variable AZURE_AUTH_LOCATION.
- * @param {string} [options.subscriptionEnvVariableName] - The subscriptionId environment variable
+ * @param options.subscriptionEnvVariableName - The subscriptionId environment variable
  * name. Default is "AZURE_SUBSCRIPTION_ID".
- * @param {function} [optionalCallback] The optional callback.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {Promise<AuthResponse>} A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
+ * @returns A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
  */
 export async function withAuthFileWithAuthResponse(options?: LoginWithAuthFileOptions): Promise<AuthResponse> {
   if (!options) options = { filePath: "" };
@@ -405,29 +405,29 @@ export async function withAuthFileWithAuthResponse(options?: LoginWithAuthFileOp
  *
  * When using personal accounts, the `domain` property in the `options` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {object} [options] Object representing optional parameters.
+ * @param options - Object representing optional parameters.
  *
- * @param {string} [options.clientId] The active directory application client id.
+ * @param options.clientId - The active directory application client id.
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
  *
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid value is "graph".If tokenAudience is provided
+ * @param options.tokenAudience - The audience for which the token is requested. Valid value is "graph".If tokenAudience is provided
  * then domain should also be provided its value should not be the default "common" tenant. It must be a string (preferably in a guid format).
  *
- * @param {string} [options.domain] The domain or tenant Id containing this application. Default value is "common".
+ * @param options.domain - The domain or tenant Id containing this application. Default value is "common".
  *
- * @param {Environment} [options.environment] The azure environment to authenticate with. Default environment is "Public Azure".
+ * @param options.environment - The azure environment to authenticate with. Default environment is "Public Azure".
  *
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
  *
- * @param {object} [options.language] The language code specifying how the message should be localized to. Default value "en-us".
+ * @param options.language - The language code specifying how the message should be localized to. Default value "en-us".
  *
- * @param {object|function} [options.userCodeResponseLogger] A logger that logs the user code response message required for interactive login. When
+ * @param options.userCodeResponseLogger - A logger that logs the user code response message required for interactive login. When
  * this option is specified the usercode response message will not be logged to console.
  *
- * @param {function} [optionalCallback] The optional callback.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {Promise<AuthResponse>} A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
+ * @returns A Promise that resolves to AuthResponse, which contains "credentials" and optional "subscriptions" array and rejects with an Error.
  */
 export async function withInteractiveWithAuthResponse(options?: InteractiveLoginOptions): Promise<AuthResponse> {
   if (!options) {
@@ -541,14 +541,14 @@ export async function withInteractiveWithAuthResponse(options?: InteractiveLogin
  * the subscriptionId from the auth file to the user provided environment variable in the options
  * parameter or the default "AZURE_SUBSCRIPTION_ID".
  *
- * @param {object} [options] - Optional parameters
- * @param {string} [options.filePath] - Absolute file path to the auth file. If not provided
+ * @param options - Optional parameters
+ * @param options.filePath - Absolute file path to the auth file. If not provided
  * then please set the environment variable AZURE_AUTH_LOCATION.
- * @param {string} [options.subscriptionEnvVariableName] - The subscriptionId environment variable
+ * @param options.subscriptionEnvVariableName - The subscriptionId environment variable
  * name. Default is "AZURE_SUBSCRIPTION_ID".
- * @param {function} [optionalCallback] The optional callback.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {function | Promise} If a callback was passed as the last parameter then it returns the callback else returns a Promise.
+ * @returns If a callback was passed as the last parameter then it returns the callback else returns a Promise.
  *
  *    {function} optionalCallback(err, credentials)
  *                 {Error}  [err]                               - The Error object if an error occurred, null otherwise.
@@ -587,21 +587,21 @@ export function withAuthFile(options?: LoginWithAuthFileOptions, callback?: { (e
  *
  * When using personal accounts, the `domain` property in the `options` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {object} [options] Object representing optional parameters.
- * @param {string} [options.clientId] The active directory application client id.
+ * @param options - Object representing optional parameters.
+ * @param options.clientId - The active directory application client id.
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid value is "graph".If tokenAudience is provided
+ * @param options.tokenAudience - The audience for which the token is requested. Valid value is "graph".If tokenAudience is provided
  * then domain should also be provided its value should not be the default "common" tenant. It must be a string (preferably in a guid format).
- * @param {string} [options.domain] The domain or tenant Id containing this application. Default value is "common".
- * @param {Environment} [options.environment] The azure environment to authenticate with. Default environment is "Public Azure".
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
- * @param {object} [options.language] The language code specifying how the message should be localized to. Default value "en-us".
- * @param {object|function} [options.userCodeResponseLogger] A logger that logs the user code response message required for interactive login. When
+ * @param options.domain - The domain or tenant Id containing this application. Default value is "common".
+ * @param options.environment - The azure environment to authenticate with. Default environment is "Public Azure".
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
+ * @param options.language - The language code specifying how the message should be localized to. Default value "en-us".
+ * @param options.userCodeResponseLogger - A logger that logs the user code response message required for interactive login. When
  * this option is specified the usercode response message will not be logged to console.
- * @param {function} [optionalCallback] The optional callback.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {function | Promise} If a callback was passed as the last parameter then it returns the callback else returns a Promise.
+ * @returns If a callback was passed as the last parameter then it returns the callback else returns a Promise.
  *
  *    {function} optionalCallback(err, credentials)
  *                 {Error}                          [err]  - The Error object if an error occurred, null otherwise.
@@ -640,19 +640,19 @@ export function interactive(options?: InteractiveLoginOptions, callback?: { (err
  *
  * When using personal accounts, the `domain` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {string} clientId The active directory application client Id also known as the SPN (ServicePrincipal Name).
+ * @param clientId - The active directory application client Id also known as the SPN (ServicePrincipal Name).
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
- * @param {string} secret The application secret for the service principal.
- * @param {string} domain The domain or tenant Id containing this application.
- * @param {object} [options] Object representing optional parameters.
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+ * @param secret - The application secret for the service principal.
+ * @param domain - The domain or tenant Id containing this application.
+ * @param options - Object representing optional parameters.
+ * @param options.tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
  * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
- * @param {Environment} [options.environment] The azure environment to authenticate with.
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
- * @param {function} [optionalCallback] The optional callback.
+ * @param options.environment - The azure environment to authenticate with.
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {function | Promise} If a callback was passed as the last parameter then it returns the callback else returns a Promise.
+ * @returns If a callback was passed as the last parameter then it returns the callback else returns a Promise.
  *
  *    {function} optionalCallback(err, credentials)
  *                 {Error}                               [err]  - The Error object if an error occurred, null otherwise.
@@ -691,21 +691,21 @@ export function withServicePrincipalSecret(clientId: string, secret: string, dom
  *
  * When using personal accounts, the `domain` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {string} clientId The active directory application client Id also known as the SPN (ServicePrincipal Name).
+ * @param clientId - The active directory application client Id also known as the SPN (ServicePrincipal Name).
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
- * @param {string} certificateStringOrFilePath A PEM encoded certificate and private key OR an absolute filepath to the .pem file containing that information. For example:
+ * @param certificateStringOrFilePath - A PEM encoded certificate and private key OR an absolute filepath to the .pem file containing that information. For example:
  * - CertificateString: "-----BEGIN PRIVATE KEY-----\n<xxxxx>\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\n<yyyyy>\n-----END CERTIFICATE-----\n"
  * - CertificateFilePath: **Absolute** file path of the .pem file.
- * @param {string} domain The domain or tenant Id containing this application.
- * @param {object} [options] Object representing optional parameters.
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+ * @param domain - The domain or tenant Id containing this application.
+ * @param options - Object representing optional parameters.
+ * @param options.tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
  * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
- * @param {Environment} [options.environment] The azure environment to authenticate with.
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
- * @param {function} [optionalCallback] The optional callback.
+ * @param options.environment - The azure environment to authenticate with.
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {function | Promise} If a callback was passed as the last parameter then it returns the callback else returns a Promise.
+ * @returns If a callback was passed as the last parameter then it returns the callback else returns a Promise.
  *
  *    {function} optionalCallback(err, credentials)
  *                 {Error}  [err]                               - The Error object if an error occurred, null otherwise.
@@ -746,20 +746,20 @@ export function withServicePrincipalCertificate(clientId: string, certificateStr
  *
  * When using personal accounts, the `domain` property in the `options` parameter is required to be set to the Id of a tenant for that account. Otherwise, the resulting credential will not be able to access the account's resources.
  *
- * @param {string} username The user name for the Organization Id account.
- * @param {string} password The password for the Organization Id account.
- * @param {object} [options] Object representing optional parameters.
- * @param {string} [options.clientId] The active directory application client id.
+ * @param username - The user name for the Organization Id account.
+ * @param password - The password for the Organization Id account.
+ * @param options - Object representing optional parameters.
+ * @param options.clientId - The active directory application client id.
  * See {@link https://azure.microsoft.com/en-us/documentation/articles/active-directory-devquickstarts-dotnet/ Active Directory Quickstart for .Net}
  * for an example.
- * @param {string} [options.tokenAudience] The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
+ * @param options.tokenAudience - The audience for which the token is requested. Valid values are 'graph', 'batch', or any other resource like 'https://vault.azure.net/'.
  * If tokenAudience is 'graph' then domain should also be provided and its value should not be the default 'common' tenant. It must be a string (preferably in a guid format).
- * @param {string} [options.domain] The domain or tenant Id containing this application. Default value "common".
- * @param {Environment} [options.environment] The azure environment to authenticate with.
- * @param {object} [options.tokenCache] The token cache. Default value is the MemoryCache object from adal.
- * @param {function} [optionalCallback] The optional callback.
+ * @param options.domain - The domain or tenant Id containing this application. Default value "common".
+ * @param options.environment - The azure environment to authenticate with.
+ * @param options.tokenCache - The token cache. Default value is the MemoryCache object from adal.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {function | Promise} If a callback was passed as the last parameter then it returns the callback else returns a Promise.
+ * @returns If a callback was passed as the last parameter then it returns the callback else returns a Promise.
  *
  *    {function} optionalCallback(err, credentials)
  *                 {Error}  [err]                         - The Error object if an error occurred, null otherwise.
@@ -810,12 +810,12 @@ function _getSubscriptions(
 /**
  * Initializes MSITokenCredentials class and calls getToken and returns a token response.
  *
- * @param {string} domain - required. The tenant id.
- * @param {object} options - Optional parameters
- * @param {string} [options.port] - port on which the MSI service is running on the host VM. Default port is 50342
- * @param {string} [options.resource] - The resource uri or token audience for which the token is needed. Default - "https://management.azure.com/"
- * @param {string} [options.aadEndpoint] - The add endpoint for authentication. default - "https://login.microsoftonline.com"
- * @param {any} callback - the callback function.
+ * @param domain - - required. The tenant id.
+ * @param options - - Optional parameters
+ * @param options.port - port on which the MSI service is running on the host VM. Default port is 50342
+ * @param options.resource - The resource uri or token audience for which the token is needed. Default - "https://management.azure.com/"
+ * @param options.aadEndpoint - The add endpoint for authentication. default - "https://login.microsoftonline.com"
+ * @param callback - - the callback function.
  */
 async function _withMSI(options?: MSIVmOptions): Promise<MSIVmTokenCredentials> {
   if (!options) {
@@ -846,15 +846,15 @@ async function _withMSI(options?: MSIVmOptions): Promise<MSIVmTokenCredentials> 
  * This method makes a request to the authentication service hosted on the VM
  * and gets back an access token.
  *
- * @param {object} [options] - Optional parameters
- * @param {string} [options.port] - port on which the MSI service is running on the host VM. Default port is 50342
- * @param {string} [options.resource] - The resource uri or token audience for which the token is needed.
+ * @param options - Optional parameters
+ * @param options.port - port on which the MSI service is running on the host VM. Default port is 50342
+ * @param options.resource - The resource uri or token audience for which the token is needed.
  * For e.g. it can be:
  * - resourcemanagement endpoint "https://management.azure.com/"(default)
  * - management endpoint "https://management.core.windows.net/"
- * @param {function} [optionalCallback] The optional callback.
+ * @param optionalCallback - The optional callback.
  *
- * @returns {function | Promise} If a callback was passed as the last parameter then it returns the callback else returns a Promise.
+ * @returns If a callback was passed as the last parameter then it returns the callback else returns a Promise.
  *
  *    {function} optionalCallback(err, credentials)
  *                 {Error}  [err]                               - The Error object if an error occurred, null otherwise.
@@ -900,20 +900,20 @@ async function _withAppServiceMSI(options: MSIAppServiceOptions): Promise<MSIApp
 
 /**
  * Authenticate using the App Service MSI.
- * @param {object} [options] - Optional parameters
- * @param {string} [options.msiEndpoint] - The local URL from which your app can request tokens.
+ * @param options - Optional parameters
+ * @param options.msiEndpoint - The local URL from which your app can request tokens.
  * Either provide this parameter or set the environment variable `MSI_ENDPOINT`.
  * For example: `MSI_ENDPOINT="http://127.0.0.1:41741/MSI/token/"`
- * @param {string} [options.msiSecret] - The secret used in communication between your code and the local MSI agent.
+ * @param options.msiSecret - The secret used in communication between your code and the local MSI agent.
  * Either provide this parameter or set the environment variable `MSI_SECRET`.
  * For example: `MSI_SECRET="69418689F1E342DD946CB82994CDA3CB"`
- * @param {string} [options.resource] - The resource uri or token audience for which the token is needed.
+ * @param options.resource - The resource uri or token audience for which the token is needed.
  * For example, it can be:
  * - resourcemanagement endpoint "https://management.azure.com/"(default)
  * - management endpoint "https://management.core.windows.net/"
- * @param {string} [options.msiApiVersion] - The api-version of the local MSI agent. Default value is "2017-09-01".
- * @param {function} [optionalCallback] -  The optional callback.
- * @returns {function | Promise} If a callback was passed as the last parameter then it returns the callback else returns a Promise.
+ * @param options.msiApiVersion - The api-version of the local MSI agent. Default value is "2017-09-01".
+ * @param optionalCallback -  The optional callback.
+ * @returns If a callback was passed as the last parameter then it returns the callback else returns a Promise.
  *
  *    {function} optionalCallback(err, credentials)
  *                 {Error}  [err]                               - The Error object if an error occurred, null otherwise.

--- a/lib/subscriptionManagement/subscriptionUtils.ts
+++ b/lib/subscriptionManagement/subscriptionUtils.ts
@@ -7,74 +7,74 @@ import { ApplicationTokenCredentialsBase } from "../credentials/applicationToken
 import { AuthConstants } from "../util/authConstants";
 
 /**
- * @interface UserType Provides information about user type. It can currently be "user" or "servicePrincipal".
+ * Provides information about user type. It can currently be "user" or "servicePrincipal".
  */
 export type UserType = "user" | "servicePrincipal";
 
 /**
- * @interface LinkedUser Provides information about a user from the authentication perspective.
+ * Provides information about a user from the authentication perspective.
  */
 export interface LinkedUser {
   /**
-   * @property {string} name - The user name. For ApplicationTokenCredentials it can be the clientId or SPN.
+   * The user name. For ApplicationTokenCredentials it can be the clientId or SPN.
    */
   name: string;
   /**
-   * @property {string} type - The user type. "user" | "servicePrincipal".
+   * The user type. "user" | "servicePrincipal".
    */
   type: UserType;
 }
 
 /**
- * @interface LinkedSubscription Provides information about subscription that was found
+ * Provides information about subscription that was found
  * during the authentication process. The structure of this type is different from the
  * subscription object that one gets by making a request to the ResourceManager API.
  */
 export interface LinkedSubscription {
   /**
-   * @property {string} tenantId - The tenant that the subscription belongs to.
+   * The tenant that the subscription belongs to.
    */
   readonly tenantId: string;
   /**
-   * @property {string} user - The user associated with the subscription. This could be a user or a serviceprincipal.
+   * The user associated with the subscription. This could be a user or a serviceprincipal.
    */
   readonly user: LinkedUser;
   /**
-   * @property {string} environmentName - The environment name in which the subscription exists.
+   * The environment name in which the subscription exists.
    * Possible values: "AzureCloud", "AzureChinaCloud", "AzureUSGovernment", "AzureGermanCloud" or
    * some other custom/internal environment name like "Dogfood".
    */
   readonly environmentName: string;
   /**
-   * @property {string} name - The display name of the subscription.
+   * The display name of the subscription.
    */
   readonly name: string;
   /**
-   * @property {string} id - The subscription id, usually a GUID.
+   * The subscription id, usually a GUID.
    */
   readonly id: string;
   /**
-   * @property {string} authorizationSource - The authorization source of the subscription: "RoleBased",
+   * The authorization source of the subscription: "RoleBased",
    *  "Legacy", "Bypassed"," Direct", "Management". It could also be a comma separated string containing
    *  more values "Bypassed, Direct, Management".
    */
   readonly authorizationSource: string;
   /**
-   * @property {string} state - The state of the subscription. Example values: "Enabled", "Disabled",
+   * The state of the subscription. Example values: "Enabled", "Disabled",
    *  "Warned", "PastDue", "Deleted".
    */
   readonly state: string;
   /**
-   * @property {any} any Placeholder for unknown properties.
+   * Placeholder for unknown properties.
    */
   readonly [x: string]: any;
 }
 
 /**
  * Builds an array of tenantIds.
- * @param {TokenCredentialsBase} credentials The credentials.
- * @param {string} apiVersion default value 2016-06-01
- * @returns {Promise<string[]>} resolves to an array of tenantIds and rejects with an error.
+ * @param credentials - The credentials.
+ * @param apiVersion - default value 2016-06-01
+ * @returns A promise that resolves to an array of tenantIds and rejects with an error.
  */
 export async function buildTenantList(credentials: TokenCredentialsBase, apiVersion = "2016-06-01"): Promise<string[]> {
   if (credentials.domain && credentials.domain !== AuthConstants.AAD_COMMON_TENANT) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
The current format of  `@property`, `@param` and `@returns` tags where type information is added does not get rendered as needed

Example: 
![image](https://user-images.githubusercontent.com/16890566/107814691-2a8d7d80-6d27-11eb-8b84-1eab118d9f40.png)

Since the source code in this package uses TypeScript and not JavaScript, we can simplify the docs as follows
- Use `@returns` instead of `@return` as per TSDoc
- Avoid type information in `@property`, `@param` and `@returns` tags
- Remove the return tag if there is no info to provide other than type info
- Remove tags like `@constructor`, `memberof`,  `@interface` and `@class` that are not needed in TS files

