### PR TITLE
Stengthen types around AuthResponse

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0 - Unreleased
+
+- Use stronger types in places where AuthResponse was used in return values that used the abstract base class `TokenCredentialsBase`. See [PR 121](https://github.com/Azure/ms-rest-nodeauth/pull/121) for details.
+
 ## 3.0.10 - 2021/05/20
 
 - Updated the dependency `adal-node` to version `^0.2.0`. This fixes customer issue: [125](https://github.com/Azure/ms-rest-nodeauth/issues/125).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.10",
+  "version": "3.1.0",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",


### PR DESCRIPTION
This PR strengthens the types around AuthReponse inspired by the changes in #75
Creating this PR as we did not get a response to https://github.com/Azure/ms-rest-nodeauth/pull/75#issuecomment-770492773

Additionally, this updates the `execAz` command to return a rejected promise when there is no output from running the az command