### PR TITLE
Arguments passed to execFile should be array of strings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,19 +1,25 @@
 # Changelog
 
-## 3.0.9 - Unreleased
+## 3.0.9 - 2021/03/30
+
 - Pass user provided `tokenCache` option to `withUsernamePasswordWithAuthResponse` and `withServicePrincipalSecretWithAuthResponse` methods to the credentials being created.
+- Fix issue with `AzureCliCredentials` where the `az` command fails due to spaces in the argument list passed to `execFile`. This regression got introduced in the previous update.
 
 ## 3.0.8 - 2021/03/23
+
 - Fix command injection in core function `execAz()` by replacing `exec()` with `execFile()` - CVE-2021-28458
 
 ## 3.0.7 - 2021/02/23
+
 - Updated doc comments on all exported members to follow TSDoc for better API reference documentation.
 
 ## 3.0.6 - 2020/09/25
+
 - Fixed a bug where `buildTenantsList` will throw an error when it can't list tenants
 - Added instructions for authenticating with an existing token
 
 ## 3.0.5 - 2020/06/16
+
 - The helper method `buildTenantList` is made public. This is helpful if one needs to get the Ids of all the tenants in the account programmatically.
 - A new method `setDomain()` which takes the Id of a tenant is now available on all credentials. Use this to change the domain i.e. the tenant against which tokens are created.
 - Fixed typos in error messages.
@@ -21,47 +27,59 @@
 - Added support for the `IDENTITY_ENDPOINT` and `IDENTITY_SECRET` when using the `MSIAppServiceTokenCredentials` credentials.
 
 ## 3.0.4 - 2020/05/19 (deprecated)
+
 - Through a mistake of release automation, a CI job from PR #91 got shipped by accident.
 
 ## 3.0.3 - 2019/08/22
+
 - Fixed a bug where the callback to `loginWithServicePrincipalSecretWithAuthResponse` is sometimes not called.
-For more details, see [PR 77](https://github.com/Azure/ms-rest-nodeauth/pull/77)
+  For more details, see [PR 77](https://github.com/Azure/ms-rest-nodeauth/pull/77)
 
 ## 3.0.2 - 2019/08/16
+
 - Fix bug prevent tenant IDs from being discovered on auth
 
 ## 3.0.1 - 2019/08/06
+
 - Reduce number of `Promise` object allocations inside `async` functions.
 
 ## 3.0.0 - 2019/08/02
+
 - **Breaking change:**
   - Updated min version of dependency `@azure/ms-rest-js` from `^1.8.13` to `^2.0.4` there by fixing [#67](https://github.com/Azure/ms-rest-nodeauth/issues/67).
 
 ## 2.0.6 - 2020/09/24
+
 - Fixed a bug where `buildTenantsList` will throw an error when it can't list tenants
 - Added instructions for authenticating with an existing token
 
 ## 2.0.5 - 2019/08/22
+
 - Fixed a bug where the callback to `loginWithServicePrincipalSecretWithAuthResponse` is sometimes not called.
 - Fix bug prevent tenant IDs from being discovered on auth
 - Reduce number of `Promise` object allocations inside `async` functions.
 
 ## 2.0.4 - 2019/08/02
+
 - Rolled back the min version of dependency `@azure/ms-rest-js` from `^2.0.3` to `^1.8.13` thereby fixing [#69](https://github.com/Azure/ms-rest-nodeauth/issues/69).
 
 ## 2.0.3 - 2019/07/23
+
 - Updated min version of dependency `@azure/ms-rest-js` to `^2.0.3`.
 - Updated min version of dependency `@azure/ms-rest-azure-env` to `^2.0.0`.
 - Improved documentation of `MSIOptions.resource`
 - Improved samples in README.md
 
 ## 2.0.2 - 2019/06/13
- - Ensure we always get JSON responses back from Azure CLI.
+
+- Ensure we always get JSON responses back from Azure CLI.
 
 ## 2.0.1 - 2019/05/22
- - Get subscriptions while authenticating only if the token audience is for Azure Resource Manager.
+
+- Get subscriptions while authenticating only if the token audience is for Azure Resource Manager.
 
 ## 2.0.0 - 2019/05/20
+
 - Added support for client_id, object_id and ms_res_id query parameters for VmMSI. Fixes [#58](https://github.com/Azure/ms-rest-nodeauth/issues/58).
 - **Breaking change:**
   - Added support to get token for a different resource like Azure Keyvault, Azure Batch, Azure Graph apart from the default Azure Resource Manager resource via `AzureCliCredentials`.
@@ -69,45 +87,58 @@ For more details, see [PR 77](https://github.com/Azure/ms-rest-nodeauth/pull/77)
   - `AzureCliCredentials.getDefaultSubscription()` has been changed to `AzureCliCredentials.getSubscription(subscriptionIdOrName?: string)`.
 
 ## 1.1.1 - 2019/05/16
+
 - Minor updates
 
 ## 1.1.0 - 2019/05/16
+
 - Added support to get credentials from `Azure CLI`, provided the user is already logged in via CLI.
-These credentials can be used by the SDK to make requests to Azure. Fixes,
+  These credentials can be used by the SDK to make requests to Azure. Fixes,
 - [azure-sdk-for-js/issues/2810](https://github.com/Azure/azure-sdk-for-js/issues/2810)
 - [azure-sdk-for-node/issues/2284](https://github.com/Azure/azure-sdk-for-node/issues/2284).
 
 ## 1.0.1 - 2019/05/06
+
 - Update README.md
 - Fix repository url in package.json
 
 ## 1.0.0 - 2019/05/06
+
 - Added support for ServicePrincipal login with certificates.
 - Updated dependencies to their latest versions.
 
 ## 0.9.3 - 2019/04/04
+
 - Updated `@azure/ms-rest-js` to the latest version `^1.8.1`.
 
 ## 0.9.2 - 2019/03/26
-- Updated the return types  for calls using interactive login, user name/ password and service principal to return the right types with promise flavor methods.
+
+- Updated the return types for calls using interactive login, user name/ password and service principal to return the right types with promise flavor methods.
 
 ## 0.9.1 - 2019/01/15
+
 - Fixed issues in AppService MSI login.
 - Improved documentation of `MSIAppServiceTokenCredentials.getToken()`
+
 ## 0.9.0 - 2019/01/11
+
 - Added support for custom MSI endpoint.
 
 ## 0.8.4 - 2019/01/09
+
 - Exported MSI login methods from the package.
 
 ## 0.8.3 - 2018/12/18
+
 - Added a check for verifying the package.json version
 - Added azure pipelines for CI.
 
 ## 0.8.2 - 2018/11/19
+
 - Fixed incorrect path in the "main" node of package.json.
 
 ## 0.8.1 - 2018/11/19
+
 - Added owners and issue template.
 - Improved internal structure of the package.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.9 - 2021/03/30
+## 3.0.9 - 2021/03/31
 
 - Pass user provided `tokenCache` option to `withUsernamePasswordWithAuthResponse` and `withServicePrincipalSecretWithAuthResponse` methods to the credentials being created.
 - Fix issue with `AzureCliCredentials` where the `az` command fails due to spaces in the argument list passed to `execFile`. This regression got introduced in the previous update.

--- a/lib/credentials/azureCliCredentials.ts
+++ b/lib/credentials/azureCliCredentials.ts
@@ -228,14 +228,16 @@ export class AzureCliCredentials implements TokenClientCredentials {
    */
   static async getAccessToken(options: AccessTokenOptions = {}): Promise<CliAccessToken> {
     try {
-      let cmd = "account get-access-token";
+      const cmdArguments = ["account", "get-access-token"];
       if (options.subscriptionIdOrName) {
-        cmd += ` -s "${options.subscriptionIdOrName}"`;
+        cmdArguments.push("-s");
+        cmdArguments.push(options.subscriptionIdOrName);
       }
       if (options.resource) {
-        cmd += ` --resource ${options.resource}`;
+        cmdArguments.push("--resource");
+        cmdArguments.push(options.resource);
       }
-      const result: any = await execAz(cmd);
+      const result: any = await execAz(cmdArguments);
       result.expiresOn = new Date(result.expiresOn);
       return result as CliAccessToken;
     } catch (err) {
@@ -258,11 +260,12 @@ export class AzureCliCredentials implements TokenClientCredentials {
       throw new Error("'subscriptionIdOrName' must be a non-empty string.");
     }
     try {
-      let cmd = "account show";
+      const cmdArguments = ["account", "show"];
       if (subscriptionIdOrName) {
-        cmd += ` -s "${subscriptionIdOrName}"`;
+        cmdArguments.push("-s");
+        cmdArguments.push(subscriptionIdOrName);
       }
-      const result: LinkedSubscription = await execAz(cmd);
+      const result: LinkedSubscription = await execAz(cmdArguments);
       return result;
     } catch (err) {
       const message =
@@ -279,7 +282,7 @@ export class AzureCliCredentials implements TokenClientCredentials {
    */
   static async setDefaultSubscription(subscriptionIdOrName: string): Promise<void> {
     try {
-      await execAz(`account set -s ${subscriptionIdOrName}`);
+      await execAz(["account", "set", "-s", subscriptionIdOrName]);
     } catch (err) {
       const message =
         `An error occurred while setting the current subscription from ` +
@@ -297,14 +300,14 @@ export class AzureCliCredentials implements TokenClientCredentials {
   ): Promise<LinkedSubscription[]> {
     let subscriptionList: any[] = [];
     try {
-      let cmd = "account list";
+      const cmdArguments = ["account", "list"];
       if (options.all) {
-        cmd += " --all";
+        cmdArguments.push(" --all");
       }
       if (options.refresh) {
-        cmd += "--refresh";
+        cmdArguments.push("--refresh");
       }
-      subscriptionList = await execAz(cmd);
+      subscriptionList = await execAz(cmdArguments);
       if (subscriptionList && subscriptionList.length) {
         for (const sub of subscriptionList) {
           if (sub.cloudName) {

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -3,7 +3,7 @@
 
 import * as adal from "adal-node";
 import * as msRest from "@azure/ms-rest-js";
-import { execFile, spawn, spawnSync } from "child_process";
+import { execFile } from "child_process";
 import { readFileSync } from "fs";
 import { Environment } from "@azure/ms-rest-azure-env";
 import { TokenCredentialsBase } from "./credentials/tokenCredentialsBase";

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -1220,7 +1220,7 @@ export function loginWithAppServiceMSI(
  */
 export async function execAz(cmd: string): Promise<any> {
   return new Promise<any>((resolve, reject) => {
-    execFile(`az`, [cmd, `--out json`], { encoding: "utf8" }, (error, stdout) => {
+    execFile(`az`, [cmd, "--out", "json"], { encoding: "utf8" }, (error, stdout) => {
       if (error) {
         return reject(error);
       }

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -3,7 +3,7 @@
 
 import * as adal from "adal-node";
 import * as msRest from "@azure/ms-rest-js";
-import { execFile } from "child_process";
+import { execFile, spawn, spawnSync } from "child_process";
 import { readFileSync } from "fs";
 import { Environment } from "@azure/ms-rest-azure-env";
 import { TokenCredentialsBase } from "./credentials/tokenCredentialsBase";
@@ -1216,11 +1216,11 @@ export function loginWithAppServiceMSI(
 /**
  * Executes the azure cli command and returns the result. It will be `undefined` if the command did
  * not return anything or a `JSON object` if the command did return something.
- * @param cmd The az cli command to execute.
+ * @param cmdArguments Arguments to the az cli command to execute.
  */
-export async function execAz(cmd: string): Promise<any> {
+export async function execAz(cmdArguments: string[]): Promise<any> {
   return new Promise<any>((resolve, reject) => {
-    execFile(`az`, [cmd, "--out", "json"], { encoding: "utf8" }, (error, stdout) => {
+    execFile(`az`, [...cmdArguments, "--out", "json"], { encoding: "utf8" }, (error, stdout) => {
       if (error) {
         return reject(error);
       }
@@ -1230,7 +1230,7 @@ export async function execAz(cmd: string): Promise<any> {
         } catch (err) {
           const msg =
             `An error occurred while parsing the output "${stdout}", of ` +
-            `the cmd "${cmd}": ${err.stack}.`;
+            `the cmd az "${cmdArguments}": ${err.stack}.`;
           return reject(new Error(msg));
         }
       }

--- a/lib/login.ts
+++ b/lib/login.ts
@@ -1219,8 +1219,9 @@ export function loginWithAppServiceMSI(
  * @param cmdArguments Arguments to the az cli command to execute.
  */
 export async function execAz(cmdArguments: string[]): Promise<any> {
+  const azCmd = process.platform === "win32" ? "az.cmd" : "az";
   return new Promise<any>((resolve, reject) => {
-    execFile(`az`, [...cmdArguments, "--out", "json"], { encoding: "utf8" }, (error, stdout) => {
+    execFile(azCmd, [...cmdArguments, "--out", "json"], { encoding: "utf8" }, (error, stdout) => {
       if (error) {
         return reject(error);
       }


### PR DESCRIPTION
Fixes #122 by updating the execFile method to take array of strings representing the cmd arguments