### PR TITLE
Adal update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.10 - 2021/05/20
+
+- Updated the dependency `adal-node` to version `^0.2.0`. This fixes customer issue: [125](https://github.com/Azure/ms-rest-nodeauth/issues/125).
+
 ## 3.0.9 - 2021/03/31
 
 - Pass user provided `tokenCache` option to `withUsernamePasswordWithAuthResponse` and `withServicePrincipalSecretWithAuthResponse` methods to the credentials being created.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-nodeauth"
   },
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "Azure Authentication library in node.js with type definitions.",
   "keywords": [
     "node",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@azure/ms-rest-azure-env": "^2.0.0",
     "@azure/ms-rest-js": "^2.0.4",
-    "adal-node": "^0.1.28"
+    "adal-node": "^0.2.2"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
I tested some of the credentials using adal-node locally. Nothing failed. Tests also pass.

I also checked adal-node's changelog and all of the changes from v0.1.x to v0.2.x seem safe.

Credentials tested:

- withUsernamePassword with and without tokenCache.
- withServicePrincipalSecretWithAuthResponse with and without tokenCache.
- withInteractiveWithAuthResponse with and without tokenCache.

The token cache does avoid further requests 👍

Given that adal-node is found on:

```
grep -rin adal-node lib/
lib/credentials/keyVaultFactory.ts:12:import { AuthenticationContext, TokenResponse, ErrorResponse } from "adal-node";
lib/credentials/applicationTokenCredentials.ts:7:import { TokenResponse, ErrorResponse, TokenCache } from "adal-node";
lib/credentials/applicationTokenCertificateCredentials.ts:9:import { TokenResponse, ErrorResponse, TokenCache } from "adal-node";
lib/credentials/tokenCredentialsBase.ts:8:import { TokenResponse, AuthenticationContext, MemoryCache, ErrorResponse, TokenCache } from "adal-node";
lib/credentials/applicationTokenCredentialsBase.ts:7:import { TokenCache, TokenResponse } from "adal-node";
lib/credentials/userTokenCredentials.ts:7:import { TokenResponse, ErrorResponse, TokenCache } from "adal-node";
lib/credentials/deviceTokenCredentials.ts:7:import { TokenResponse, TokenCache } from "adal-node";
```

I believe that what's relevant that I haven't tested yet is the `withServicePrincipalCertificateWithAuthResponse`. However, given the adal-node changelog has so few changes between these versions, and that the core features from adal-node do work (as tested through the other credentials), I believe this update is safe to merge.

Fixes https://github.com/Azure/ms-rest-nodeauth/issues/125