### PR TITLE
Migration to Identity: Issues in the code snippets

### DIFF
--- a/migrate-to-identity-v2.md
+++ b/migrate-to-identity-v2.md
@@ -108,7 +108,7 @@ const credential = new ClientSecretCredential(
 You will continue specifying a `baseUri` when creating the client in the Azure package to point to the correct scope relative to a national cloud. An example follows:
 
 ```diff
-- import { ApplicationTokenCredentials } from "@azure/ms-rest-nodeauth";
+- import { loginWithServicePrincipalSecret } from "@azure/ms-rest-nodeauth";
 + import { ClientSecretCredential, AzureAuthorityHosts } from "@azure/identity";
 - import { Environment } from "@azure/ms-rest-azure-env";
 import { SubscriptionClient } from "@azure/arm-subscriptions";
@@ -119,16 +119,14 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 const clientId = process.env.AZURE_CLIENT_ID;
-const domain = process.env.AZURE_TENANT_ID;
-const tenantId = process.env.AZURE_TENANT_ID;
-const secret = "process.env.AZURE_CLIENT_SECRET;
-- const tokenAudience = "https://management.chinacloudapi.cn/";
+const domain = process.env.AZURE_TENANT_ID; // domain or tenantId
+const secret = process.env.AZURE_CLIENT_SECRET;
 - const environment = Environment.ChinaCloud;
++ const authorityHost = AzureAuthorityHosts.AzureChina;
+
 async function main() {
-- const credential = new ApplicationTokenCredentials(clientId, domain, secret, tokenAudience, environment);
-+ const credential = new ClientSecretCredential(tenantId, clientId, secret, {
-+  authorityHost: AzureAuthorityHosts.AzureChina
-+ });
+- const credential = await loginWithServicePrincipalSecret(clientId, secret, domain, { environment });
++ const credential = new ClientSecretCredential(domain, clientId, secret, { authorityHost });
   const client = new SubscriptionClient(credential, {
 -  baseUri: environment.resourceManagerEndpointUrl,
 +  baseUri: "https://management.chinacloudapi.cn"

--- a/migrate-to-identity-v2.md
+++ b/migrate-to-identity-v2.md
@@ -127,7 +127,7 @@ const tokenAudience = "https://graph.microsoft.com/";
 
 async function main() {
 - const credential = new ApplicationTokenCredentials(clientId, domain, secret, tokenAudience, environment);
-+ const credential = new ClientSecretCredential(tenantId, clientId, secret, tokenAudience, {
++ const credential = new ClientSecretCredential(tenantId, clientId, secret, {
 +  authorityHost: AzureAuthorityHosts.AzureChina
 + });
   const client = new SubscriptionClient(credential, {
@@ -221,7 +221,8 @@ async function main() {
 -  const authResponse = await interactiveLogin({
 -    tokenAudience: "https://vault.azure.net/"
 -  });
-+  const credential = new AzureCliCredential("https://vault.azure.net/.default");
++  const credential = new InteractiveBrowserCredential();
++  const accessToken = await credential.getToken("https://vault.azure.net/.default");
 }
 
 main().catch(console.error);

--- a/migrate-to-identity-v2.md
+++ b/migrate-to-identity-v2.md
@@ -110,7 +110,7 @@ You will continue specifying a `baseUri` when creating the client in the Azure p
 ```diff
 - import { loginWithServicePrincipalSecret } from "@azure/ms-rest-nodeauth";
 + import { ClientSecretCredential, AzureAuthorityHosts } from "@azure/identity";
-- import { Environment } from "@azure/ms-rest-azure-env";
+import { Environment } from "@azure/ms-rest-azure-env";
 import { SubscriptionClient } from "@azure/arm-subscriptions";
 
 import * as msRest from "@azure/ms-rest-js";
@@ -121,15 +121,14 @@ dotenv.config();
 const clientId = process.env.AZURE_CLIENT_ID;
 const domain = process.env.AZURE_TENANT_ID; // domain or tenantId
 const secret = process.env.AZURE_CLIENT_SECRET;
-- const environment = Environment.ChinaCloud;
+const environment = Environment.ChinaCloud;
 + const authorityHost = AzureAuthorityHosts.AzureChina;
 
 async function main() {
 - const credential = await loginWithServicePrincipalSecret(clientId, secret, domain, { environment });
 + const credential = new ClientSecretCredential(domain, clientId, secret, { authorityHost });
   const client = new SubscriptionClient(credential, {
--  baseUri: environment.resourceManagerEndpointUrl,
-+  baseUri: "https://management.chinacloudapi.cn"
+   baseUri: environment.resourceManagerEndpointUrl,
   });
 
   const subscriptions = await client.subscriptions.list();

--- a/migrate-to-identity-v2.md
+++ b/migrate-to-identity-v2.md
@@ -122,9 +122,8 @@ const clientId = process.env.AZURE_CLIENT_ID;
 const domain = process.env.AZURE_TENANT_ID;
 const tenantId = process.env.AZURE_TENANT_ID;
 const secret = "process.env.AZURE_CLIENT_SECRET;
-const tokenAudience = "https://graph.microsoft.com/";
+- const tokenAudience = "https://management.chinacloudapi.cn/";
 - const environment = Environment.ChinaCloud;
-
 async function main() {
 - const credential = new ApplicationTokenCredentials(clientId, domain, secret, tokenAudience, environment);
 + const credential = new ClientSecretCredential(tenantId, clientId, secret, {
@@ -211,16 +210,17 @@ While scopes (or resources) are generally provided to the new credentials intern
 
 Scopes generally include permissions. For example, to request a token that could have read access to the currently authenticated user, the scope would be `https://graph.microsoft.com/User.Read`. An app may also request any available permission, as defined through the app registration on the Azure portal, by sending a request ending in `/.default` as the scope. For more information about Azure scopes and permissions, see [Permissions and consent in the Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent).
 
-The following example code shows how to migrate from using `@azure/ms-rest-nodeauth`'s `tokenAudience` to `@azure/identity`'s `getToken`, with a scope that grants Key Vault access:
+The following example code shows how to migrate from using `@azure/ms-rest-nodeauth`'s `getToken` to `@azure/identity`'s `getToken`, with a scope that grants Key Vault access:
 
 ```diff
 - import { interactiveLogin } from "@azure/ms-rest-nodeauth";
 + import { AzureCliCredential } from "@azure/identity";
 
 async function main() {
--  const authResponse = await interactiveLogin({
+-  const credentials = await interactiveLogin({
 -    tokenAudience: "https://vault.azure.net/"
 -  });
+-  const tokenResponse = await credentials.getToken();
 +  const credential = new InteractiveBrowserCredential();
 +  const accessToken = await credential.getToken("https://vault.azure.net/.default");
 }


### PR DESCRIPTION
This PR fixes two issues in the code snippets:

- We passed the `tokenAudience` to the `ClientSecretCredential` as a parameter when `ClientSecretCredential` does not receive such parameter.
- We were not calling the `getToken` method of the credential used in the sample for the `Regarding scopes` section. We were instead passing it to a credential.
- In the `Regarding scopes` code snippet, we were also moving from `interactiveLogin` to `AzureCliCredential`, which is confusing. Using `InteractiveBrowserCredential` instead.